### PR TITLE
Wave Pirates fix and QoL tweaks

### DIFF
--- a/generated/json_data/qol.jsonc
+++ b/generated/json_data/qol.jsonc
@@ -10473,6 +10473,19 @@
                                 20.0,
                                 10.0
                             ]
+                        },
+                        {
+                            "id": 983113, // [Trigger] Trigger_DoorOpen
+                            "position": [
+                                -694.973267,
+                                339.468536,
+                                37.531601
+                            ],
+                            "scale": [
+                                20.0,
+                                10.0,
+                                8.0
+                            ]
                         }
                     ]
                 },
@@ -12195,12 +12208,6 @@
                             "targetId": 460062, // [Counter] Counter - dead Shadow Pirates - kill upstairs
                             "state": "DEATH_RATTLE",
                             "message": "INCREMENT"
-                        },
-                        {
-                            "senderId": 459954, // [Trigger] Trigger -activate trooper
-                            "targetId": 460064, // [Relay] Relay
-                            "state": "ENTERED",
-                            "message": "DEACTIVATE"
                         },
                         {
                             "senderId": 458760, // [SpecialFunction] Music Player For Area

--- a/generated/json_data/qol.jsonc
+++ b/generated/json_data/qol.jsonc
@@ -10459,6 +10459,21 @@
                             "fadeOutTime": 1.5,
                             "audioFileName": "/audio/over-worldL.dsp|/audio/over-worldR.dsp"
                         }
+                    ],
+                    "triggers": [
+                        {
+                            "id": 983113, // [Trigger] Trigger_DoorOpen
+                            "position": [
+                                -659.227417,
+                                310.424774,
+                                -42.451237
+                            ],
+                            "scale": [
+                                10.0,
+                                20.0,
+                                10.0
+                            ]
+                        }
                     ]
                 },
                 "Root Tunnel": {
@@ -12130,7 +12145,63 @@
                         460356, // [Trigger] Trigger - Play Music 00c Isogi
                         460357 // [Trigger] Trigger - Play Music 00c Mines Main
                     ],
+                    "removeConnections": [
+                        {
+                            "senderId": 459223, // [SpacePirate] SpacePirate-MELEE
+                            "targetId": 460060, // [Counter] Counter - dead Shadow Pirates - kill before upstairs
+                            "state": "DEAD",
+                            "message": "INCREMENT"
+                        },
+                        {
+                            "senderId": 459224, // [SpacePirate] SpacePirate-MELEE
+                            "targetId": 460060, // [Counter] Counter - dead Shadow Pirates - kill before upstairs
+                            "state": "DEAD",
+                            "message": "INCREMENT"
+                        },
+                        {
+                            "senderId": 459223, // [SpacePirate] SpacePirate-MELEE
+                            "targetId": 460062, // [Counter] Counter - dead Shadow Pirates - kill upstairs
+                            "state": "DEAD",
+                            "message": "INCREMENT"
+                        },
+                        {
+                            "senderId": 459224, // [SpacePirate] SpacePirate-MELEE
+                            "targetId": 460062, // [Counter] Counter - dead Shadow Pirates - kill upstairs
+                            "state": "DEAD",
+                            "message": "INCREMENT"
+                        }
+                    ],
                     "addConnections": [
+                        {
+                            "senderId": 459223, // [SpacePirate] SpacePirate-MELEE
+                            "targetId": 460060, // [Counter] Counter - dead Shadow Pirates - kill before upstairs
+                            "state": "DEATH_RATTLE",
+                            "message": "INCREMENT"
+                        },
+                        {
+                            "senderId": 459224, // [SpacePirate] SpacePirate-MELEE
+                            "targetId": 460060, // [Counter] Counter - dead Shadow Pirates - kill before upstairs
+                            "state": "DEATH_RATTLE",
+                            "message": "INCREMENT"
+                        },
+                        {
+                            "senderId": 459223, // [SpacePirate] SpacePirate-MELEE
+                            "targetId": 460062, // [Counter] Counter - dead Shadow Pirates - kill upstairs
+                            "state": "DEATH_RATTLE",
+                            "message": "INCREMENT"
+                        },
+                        {
+                            "senderId": 459224, // [SpacePirate] SpacePirate-MELEE
+                            "targetId": 460062, // [Counter] Counter - dead Shadow Pirates - kill upstairs
+                            "state": "DEATH_RATTLE",
+                            "message": "INCREMENT"
+                        },
+                        {
+                            "senderId": 459954, // [Trigger] Trigger -activate trooper
+                            "targetId": 460064, // [Relay] Relay
+                            "state": "ENTERED",
+                            "message": "DEACTIVATE"
+                        },
                         {
                             "senderId": 458760, // [SpecialFunction] Music Player For Area
                             "targetId": 458762, // [Relay] Mines Music
@@ -12205,6 +12276,21 @@
                             "id": 458763, // [Relay] Pirates Music
                             "layer": 1,
                             "active": false
+                        }
+                    ],
+                    "triggers": [
+                        {
+                            "id": 459954, // [Trigger] Trigger -activate trooper
+                            "position": [
+                                -15.26812,
+                                20.186085,
+                                15.073245
+                            ],
+                            "scale": [
+                                16.041,
+                                4.464,
+                                11.5
+                            ]
                         }
                     ]
                 },

--- a/generated/json_data/skippable_cutscenes.jsonc
+++ b/generated/json_data/skippable_cutscenes.jsonc
@@ -19726,12 +19726,6 @@
                             "message": "SET_TO_ZERO"
                         },
                         {
-                            "senderId": 459956, // [Timer] Timer - alert Trooper
-                            "targetId": 458757, // [Relay] Relay Alert Trooper
-                            "state": "ZERO",
-                            "message": "DEACTIVATE"
-                        },
-                        {
                             "senderId": 458757, // [Relay] Relay Alert Trooper
                             "targetId": 459998, // [Actor] Actor_Grating
                             "state": "ZERO",
@@ -19756,12 +19750,6 @@
                             "message": "SET_TO_ZERO"
                         },
                         {
-                            "senderId": 460046, // [Timer] Timer - alert Trooper
-                            "targetId": 458758, // [Relay] Relay Alert Trooper
-                            "state": "ZERO",
-                            "message": "DEACTIVATE"
-                        },
-                        {
                             "senderId": 458758, // [Relay] Relay Alert Trooper
                             "targetId": 460020, // [Actor] Actor_Grating
                             "state": "ZERO",
@@ -19774,16 +19762,16 @@
                             "message": "ALERT"
                         },
                         {
+                            "senderId": 458758, // [Relay] Relay Alert Trooper
+                            "targetId": 459958, // [Trigger] Trigger
+                            "state": "ZERO",
+                            "message": "DEACTIVATE"
+                        },
+                        {
                             "senderId": 458756, // [SpecialFunction] SpecialFunction Cinematic Skip
                             "targetId": 458759, // [Relay] Relay Alert Trooper
                             "state": "ZERO",
                             "message": "SET_TO_ZERO"
-                        },
-                        {
-                            "senderId": 460046, // [Timer] Timer - alert Trooper
-                            "targetId": 458759, // [Relay] Relay Alert Trooper
-                            "state": "ZERO",
-                            "message": "DEACTIVATE"
                         },
                         {
                             "senderId": 458759, // [Relay] Relay Alert Trooper


### PR DESCRIPTION
Skippable Cutscenes:
- Fixed an issue in Mine Security Station where the wave pirates won't drop down if the player didn't skip the cutscene immediately.

QoL:
- Increased the size of the top and bottom door open triggers in Root Cave
- Mine Security Station:
  - Changed the Shadow Pirates to activate the Wave Pirates cutscene upon `DeathRattle` instead of `Dead` 
  - Resized the cutscene trigger so it's not accidentaly skipped if jumped over.
