### PR TITLE
Improved SCLYObject wrapper and MlvlWrapper::MlvlArea wrapper

### DIFF
--- a/src/mlvl_wrapper.rs
+++ b/src/mlvl_wrapper.rs
@@ -82,6 +82,26 @@ impl<'r, 'mlvl, 'cursor, 'list> MlvlArea<'r, 'mlvl, 'cursor, 'list>
         layer_id.unwrap()
     }
 
+    pub fn object_id_from_layer_name(&mut self, layer_name: &str, internal_idx: usize) -> u32
+    {
+        let layer_id = self.get_layer_id_from_name(layer_name);
+        return self.object_id_from_layer_id(layer_id, internal_idx);
+    }
+
+    pub fn object_id_from_layer_id(&mut self, layer_id: usize, internal_idx: usize) -> u32
+    {
+        // initialize with the internal id
+        let mut obj_id = internal_idx;
+
+        // add the area id to the object id
+        obj_id |= self.mrea_index << 16;
+
+        // add the layer id to the object id
+        obj_id |= layer_id << 26;
+
+        obj_id as u32
+    }
+
     pub fn new_object_id_from_layer_name(&mut self, layer_name: &str) -> u32
     {
         let layer_id = self.get_layer_id_from_name(layer_name);

--- a/structs/src/scly.rs
+++ b/structs/src/scly.rs
@@ -198,6 +198,24 @@ pub struct SclyObject<'r>
     pub property_data: SclyProperty<'r>,
 }
 
+impl<'r> SclyObject<'r>
+{
+    pub fn get_layer_idx(self) -> usize
+    {
+        ((self.instance_id >> 26) & 0x3F) as usize
+    }
+
+    pub fn get_area_idx(self) -> usize
+    {
+        ((self.instance_id >> 16) & 0xFF) as usize
+    }
+
+    pub fn get_object_idx(self) -> usize
+    {
+        (self.instance_id & 0xFFFF) as usize
+    }
+}
+
 macro_rules! build_scly_property {
     ($($name:ident, $is_check:ident, $accessor:ident, $accessor_mut:ident,)*) => {
 


### PR DESCRIPTION
## Added SclyObject::get_layer_idx()
Returns the layer index that the object belongs to.

## Added SclyObject::get_area_idx()
Returns the area index that the object belongs to.

## Added SclyObject::get_internal_idx()
Returns the internal index that the object of the current area.

## Added MlvlWrapper::MlvlArea::object_id_from_layer_name(layer_name, internal_idx)
Returns an object id from the layer name and the internal index of the object.

## Added MlvlWrapper::MlvlArea::object_id_from_layer_id(layer_name, internal_idx)
Returns an object id from the layer id and the internal index of the object.