### PR TITLE
Fix config parse error

### DIFF
--- a/src/patch_config.rs
+++ b/src/patch_config.rs
@@ -1166,11 +1166,7 @@ impl<'de> Deserialize<'de> for SuitDamageReduction {
             }
         }
 
-        deserializer.deserialize_enum(
-            "SuitDamageReduction",
-            &["Default", "Progressive", "Additive"],
-            SuitDamageReductionVisitor,
-        )
+        deserializer.deserialize_any(SuitDamageReductionVisitor)
     }
 }
 


### PR DESCRIPTION
:hotdog:

Fix a config parsing error when `staggeredSuitDamage` is present in the provided JSON file.