### PR TITLE
Bug Fixes, Geothermal Core QoL

### DIFF
--- a/generated/json_data/qol.jsonc
+++ b/generated/json_data/qol.jsonc
@@ -7942,6 +7942,14 @@
                         1311599,
                         1311598
                     ],
+                    "removeConnections": [
+                        {
+                            "senderId": 1311605, // [Counter] Counter Dead Pirate Music
+                            "targetId": 1311506, // [StreamedAudio] StreamedAudio Pirate Yoin SW
+                            "state": "ZERO",
+                            "message": "PLAY"
+                        }
+                    ],
                     "addConnections": [
                         {
                             "senderId": 1310726, // [SpecialFunction] Music Player For Area
@@ -7965,6 +7973,12 @@
                             "senderId": 1310726, // [SpecialFunction] Music Player For Area
                             "targetId": 1310734, // [Relay] Pirate Battle Music
                             "state": "ENTERED",
+                            "message": "SET_TO_ZERO"
+                        },
+                        {
+                            "senderId": 1311605, // [Counter] Counter Dead Pirate Music
+                            "targetId": 1310735, // [Relay] Pirate Ambiance Music
+                            "state": "ZERO",
                             "message": "SET_TO_ZERO"
                         },
                         {
@@ -12585,48 +12599,122 @@
                         1312015,
                         1312268
                     ],
+                    "removeConnections": [
+                        {
+                            "senderId": 1311904, // [SpacePirate] SpacePirate-WAVE TROOPER
+                            "targetId": 1312016, // [Counter] Counter Dead Pirate Music
+                            "state": "DEAD",
+                            "message": "DECREMENT"
+                        },
+                        {
+                            "senderId": 1311906, // [SpacePirate] SpacePirate-WAVE TROOPER
+                            "targetId": 1312016, // [Counter] Counter Dead Pirate Music
+                            "state": "DEAD",
+                            "message": "DECREMENT"
+                        },
+                        {
+                            "senderId": 1311910, // [SpacePirate] SpacePirate-POWER TROOPER
+                            "targetId": 1312016, // [Counter] Counter Dead Pirate Music
+                            "state": "DEAD",
+                            "message": "DECREMENT"
+                        },
+                        {
+                            "senderId": 1311911, // [SpacePirate] SpacePirate-POWER TROOPER
+                            "targetId": 1312016, // [Counter] Counter Dead Pirate Music
+                            "state": "DEAD",
+                            "message": "DECREMENT"
+                        },
+                        {
+                            "senderId": 1311912, // [SpacePirate] SpacePirate-POWER TROOPER
+                            "targetId": 1312016, // [Counter] Counter Dead Pirate Music
+                            "state": "DEAD",
+                            "message": "DECREMENT"
+                        }
+                    ],
                     "addConnections": [
                         {
                             "senderId": 1310727, // [SpecialFunction] Music Player For Area
-                            "targetId": 1310729, // [Relay] 1st Pass Pirates Music
+                            "targetId": 1310729, // [Switch] OPEN: Pirate Ambiance / CLOSED: Pirate Music
                             "state": "ENTERED",
                             "message": "SET_TO_ZERO"
+                        },
+                        {
+                            "senderId": 1312016, // [Counter] Counter Dead Pirate Music
+                            "targetId": 1310729, // [Switch] OPEN: Pirate Ambiance / CLOSED: Pirate Music
+                            "state": "ZERO",
+                            "message": "OPEN"
+                        },
+                        {
+                            "senderId": 1311917, // [Relay] Relay
+                            "targetId": 1310736, // [Switch] OPEN: Pirate Ambiance / CLOSED: Elite Pirate Music
+                            "state": "ZERO",
+                            "message": "CLOSE"
+                        },
+                        {
+                            "senderId": 1311182, // [ElitePirate] ElitePirate
+                            "targetId": 1310736, // [Switch] OPEN: Pirate Ambiance / CLOSED: Elite Pirate Music
+                            "state": "DEATH_RATTLE",
+                            "message": "OPEN"
                         },
                         {
                             "senderId": 1310727, // [SpecialFunction] Music Player For Area
-                            "targetId": 1310736, // [Relay] 1st Pass Pirate Ambiance
+                            "targetId": 1310736, // [Switch] OPEN: Pirate Ambiance / CLOSED: Elite Pirate Music
                             "state": "ENTERED",
                             "message": "SET_TO_ZERO"
                         },
                         {
-                            "senderId": 1310729, // [Relay] 1st Pass Pirates Music
+                            "senderId": 1310729, // [Switch] OPEN: Pirate Ambiance / CLOSED: Pirate Music
                             "targetId": 1312018, // [StreamedAudio] StreamedAudio Pirate Battle 3 SW
-                            "state": "ZERO",
+                            "state": "CLOSED",
                             "message": "PLAY"
                         },
                         {
-                            "senderId": 1310736, // [Relay] 1st Pass Pirate Ambiance
+                            "senderId": 1310729, // [Switch] OPEN: Pirate Ambiance / CLOSED: Pirate Music
                             "targetId": 1312017, // [StreamedAudio] StreamedAudio Pirate Yoin SW
-                            "state": "ZERO",
+                            "state": "OPEN",
                             "message": "PLAY"
                         },
                         {
-                            "senderId": 1312016, // [Counter] Counter Dead Pirate Music
-                            "targetId": 1310736, // [Relay] 1st Pass Pirate Ambiance
-                            "state": "ZERO",
-                            "message": "ACTIVATE"
-                        },
-                        {
-                            "senderId": 1312016, // [Counter] Counter Dead Pirate Music
-                            "targetId": 1310729, // [Relay] 1st Pass Pirates Music
-                            "state": "ZERO",
-                            "message": "DEACTIVATE"
-                        },
-                        {
-                            "senderId": 1310727, // [SpecialFunction] Music Player For Area
+                            "senderId": 1310736, // [Switch] OPEN: Pirate Ambiance / CLOSED: Elite Pirate Music
                             "targetId": 1312221, // [StreamedAudio] StreamedAudio Pirate Yoin SW
-                            "state": "ENTERED",
+                            "state": "OPEN",
                             "message": "PLAY"
+                        },
+                        {
+                            "senderId": 1310736, // [Switch] OPEN: Pirate Ambiance / CLOSED: Elite Pirate Music
+                            "targetId": 1312220, // [StreamedAudio] StreamedAudio - General ShortBattle 2 SW
+                            "state": "CLOSED",
+                            "message": "PLAY"
+                        },
+                        {
+                            "senderId": 1311904, // [SpacePirate] SpacePirate-WAVE TROOPER
+                            "targetId": 1312016, // [Counter] Counter Dead Pirate Music
+                            "state": "DEATH_RATTLE",
+                            "message": "DECREMENT"
+                        },
+                        {
+                            "senderId": 1311906, // [SpacePirate] SpacePirate-WAVE TROOPER
+                            "targetId": 1312016, // [Counter] Counter Dead Pirate Music
+                            "state": "DEATH_RATTLE",
+                            "message": "DECREMENT"
+                        },
+                        {
+                            "senderId": 1311910, // [SpacePirate] SpacePirate-POWER TROOPER
+                            "targetId": 1312016, // [Counter] Counter Dead Pirate Music
+                            "state": "DEATH_RATTLE",
+                            "message": "DECREMENT"
+                        },
+                        {
+                            "senderId": 1311911, // [SpacePirate] SpacePirate-POWER TROOPER
+                            "targetId": 1312016, // [Counter] Counter Dead Pirate Music
+                            "state": "DEATH_RATTLE",
+                            "message": "DECREMENT"
+                        },
+                        {
+                            "senderId": 1311912, // [SpacePirate] SpacePirate-POWER TROOPER
+                            "targetId": 1312016, // [Counter] Counter Dead Pirate Music
+                            "state": "DEATH_RATTLE",
+                            "message": "DECREMENT"
                         }
                     ],
                     "specialFunctions": [
@@ -12635,15 +12723,15 @@
                             "type": "PlayerInAreaRelay"
                         }
                     ],
-                    "relays": [
+                    "switches": [
                         {
-                            "id": 1310729, // [Relay] 1st Pass Pirates Music
+                            "id": 1310729, // [Switch] OPEN: Pirate Ambiance / CLOSED: Pirate Music
                             "layer": 1
                         },
                         {
-                            "id": 1310736, // [Relay] 1st Pass Pirate Ambiance
-                            "layer": 1,
-                            "active": false
+                            "id": 1310736, // [Switch] OPEN: Pirate Ambiance / CLOSED: Elite Pirate Music
+                            "open": true,
+                            "layer": 2
                         }
                     ]
                 },
@@ -13438,12 +13526,27 @@
                     ]
                 },
                 "Geothermal Core": {
+                    "deleteIds": [
+                        1310784 // [Trigger] Trigger - exitPlat
+                    ],
                     "addConnections": [
                         {
                             "senderId": 1310760, // [SpecialFunction] Music Player For Area
                             "targetId": 1310783, // [StreamedAudio] StreamedAudio Lava Main SW
                             "state": "ENTERED",
                             "message": "PLAY"
+                        },
+                        {
+                            "senderId": 1311191, // [Camera] Cinematic Camera
+                            "targetId": 1310791, // [Timer] Platform Activate Delay
+                            "state": "ACTIVE",
+                            "message": "START"
+                        },
+                        {
+                            "senderId": 1310791, // [Timer] Platform Activate Delay
+                            "targetId": 1310782, // [Actor] Actor - exitPlat
+                            "state": "ZERO",
+                            "message": "ACTIVATE"
                         }
                     ],
                     "specialFunctions": [
@@ -13460,6 +13563,12 @@
                             "fadeInTime": 0.01,
                             "fadeOutTime": 1.5,
                             "audioFileName": "/audio/lav_lavamainL.dsp|/audio/lav_lavamainR.dsp"
+                        }
+                    ],
+                    "timers": [
+                        {
+                            "id": 1310791, // [Timer] Platform Activate Delay
+                            "time": 5.5
                         }
                     ]
                 },

--- a/generated/json_data/skippable_cutscenes.jsonc
+++ b/generated/json_data/skippable_cutscenes.jsonc
@@ -15062,7 +15062,7 @@
                     "removeConnections": [
                         {
                             "senderId": 1311461, // [Trigger] Trigger
-                            "targetId": 1311465, // [Cinematic] Cinematic Camera
+                            "targetId": 1311465, // [Camera] Cinematic Camera
                             "state": "ENTERED",
                             "message": "ACTIVATE"
                         },
@@ -15073,13 +15073,13 @@
                             "message": "RESET_AND_START"
                         },
                         {
-                            "senderId": 1311465, // [Cinematic] Cinematic Camera
+                            "senderId": 1311465, // [Camera] Cinematic Camera
                             "targetId": 1311347, // [CameraFilterKeyframe] cinema bars
                             "state": "ACTIVE",
                             "message": "INCREMENT"
                         },
                         {
-                            "senderId": 1311178, // [Cinematic] camera1 - Cinematic to start doors locking
+                            "senderId": 1311178, // [Camera] camera1 - Cinematic to start doors locking
                             "targetId": 1311347, // [CameraFilterKeyframe] cinema bars
                             "state": "INACTIVE",
                             "message": "DECREMENT"
@@ -15094,7 +15094,7 @@
                         },
                         {
                             "senderId": 1310721, // [Relay] Relay-start of cinema
-                            "targetId": 1311465, // [Cinematic] Cinematic Camera
+                            "targetId": 1311465, // [Camera] Cinematic Camera
                             "state": "ZERO",
                             "message": "ACTIVATE"
                         },
@@ -25605,12 +25605,46 @@
                             "targetId": 1311402, // [Actor] Actor - Ceiling Animation
                             "state": "ZERO",
                             "message": "DEACTIVATE"
+                        },
+                        {
+                            "senderId": 1310750, // [SpecialFunction] SpecialFunction Cinematic Skip
+                            "targetId": 1310792, // [ActorKeyframe] Platform Skip
+                            "state": "ZERO",
+                            "message": "ACTION"
+                        },
+                        {
+                            "senderId": 1310750, // [SpecialFunction] SpecialFunction Cinematic Skip
+                            "targetId": 1310791, // [Timer] Platform Activate Delay
+                            "state": "ZERO",
+                            "message": "STOP"
+                        },
+                        {
+                            "senderId": 1310792, // [ActorKeyframe] Platform Skip
+                            "targetId": 1310782, // [Actor] Actor - exitPlat
+                            "state": "PLAY",
+                            "message": "PLAY"
                         }
                     ],
                     "specialFunctions": [
                         {
                             "id": 1310750, // [SpecialFunction] SpecialFunction Cinematic Skip
                             "type": "CinematicSkip"
+                        }
+                    ],
+                    "actorKeyframes": [
+                        {
+                            "id": 1310792, // [ActorKeyframe] Platform Skip
+                            "fadeOut": 0,
+                            "looping": false,
+                            "lifetime": 0.0,
+                            "animationId": 0,
+                            "totalPlayback": 100.0
+                        }
+                    ],
+                    "timers": [
+                        {
+                            "id": 1310791, // [Timer] Platform Activate Delay
+                            "time": 5.5
                         }
                     ]
                 },
@@ -26760,6 +26794,12 @@
                             "targetId": 1769517, // [Relay] Faulty Relay - End Arriving Cinematic
                             "state": "INACTIVE",
                             "message": "SET_TO_ZERO"
+                        },
+                        {
+                            "senderId": 666666, // [Camera] Cinematic Camera Hold
+                            "targetId": 42069, // [CameraFilterKeyframe] Camera Filter Keyframe Hold Black
+                            "state": "INACTIVE",
+                            "message": "DECREMENT"
                         },
                         {
                             "senderId": 666555, // [Timer] Load Timer

--- a/generated/json_data/skippable_cutscenes.jsonc
+++ b/generated/json_data/skippable_cutscenes.jsonc
@@ -25253,7 +25253,7 @@
                         {
                             "senderId": 1179651, // [Relay] Relay-start of cinema
                             "targetId": 1179782, // [CameraFilterKeyframe] Camera Filter Keyframe Widescreen
-                            "state": "ACTIVE",
+                            "state": "ZERO",
                             "message": "INCREMENT"
                         },
                         {

--- a/generated/json_data/skippable_cutscenes.jsonc
+++ b/generated/json_data/skippable_cutscenes.jsonc
@@ -317,6 +317,7 @@
                             "id": 42069, // [CameraFilterKeyframe] Camera Filter Keyframe Hold Black
                             "filterShape": "Fullscreen",
                             "filterType": "Multiply",
+                            "filterIndex": 2,
                             "fadeOutTime": 0.5
                         }
                     ]
@@ -8956,6 +8957,7 @@
                             "id": 42069, // [CameraFilterKeyframe] Camera Filter Keyframe Hold Black
                             "filterShape": "Fullscreen",
                             "filterType": "Multiply",
+                            "filterIndex": 2,
                             "fadeOutTime": 0.5
                         }
                     ]
@@ -10100,6 +10102,7 @@
                             "id": 42069, // [CameraFilterKeyframe] Camera Filter Keyframe Hold Black
                             "filterShape": "Fullscreen",
                             "filterType": "Multiply",
+                            "filterIndex": 2,
                             "fadeOutTime": 0.5
                         }
                     ]
@@ -10392,6 +10395,7 @@
                             "id": 42069, // [CameraFilterKeyframe] Camera Filter Keyframe Hold Black
                             "filterShape": "Fullscreen",
                             "filterType": "Multiply",
+                            "filterIndex": 2,
                             "fadeOutTime": 0.5
                         }
                     ]
@@ -10678,6 +10682,7 @@
                             "id": 42069, // [CameraFilterKeyframe] Camera Filter Keyframe Hold Black
                             "filterShape": "Fullscreen",
                             "filterType": "Multiply",
+                            "filterIndex": 2,
                             "fadeOutTime": 0.5
                         }
                     ]
@@ -10952,6 +10957,7 @@
                             "id": 42069, // [CameraFilterKeyframe] Camera Filter Keyframe Hold Black
                             "filterShape": "Fullscreen",
                             "filterType": "Multiply",
+                            "filterIndex": 2,
                             "fadeOutTime": 0.5
                         }
                     ]
@@ -16431,6 +16437,15 @@
                             "morphed": true
                         }
                     ],
+                    "cameraFilterKeyframes": [
+                        {
+                            "id": 42069, // [CameraFilterKeyframe] Camera Filter Keyframe Hold Black
+                            "filterShape": "Fullscreen",
+                            "filterType": "Multiply",
+                            "filterIndex": 2,
+                            "fadeOutTime": 0.5
+                        }
+                    ],
                     "timers": [
                         {
                             "id": 1572949, // [Timer] Cutscene Skip 2 Frame Delay
@@ -16725,6 +16740,7 @@
                             "id": 42069, // [CameraFilterKeyframe] Camera Filter Keyframe Hold Black
                             "filterShape": "Fullscreen",
                             "filterType": "Multiply",
+                            "filterIndex": 2,
                             "fadeOutTime": 0.5
                         }
                     ]
@@ -17772,6 +17788,7 @@
                             "id": 42069, // [CameraFilterKeyframe] Camera Filter Keyframe Hold Black
                             "filterShape": "Fullscreen",
                             "filterType": "Multiply",
+                            "filterIndex": 2,
                             "fadeOutTime": 0.5
                         }
                     ]
@@ -19350,9 +19367,9 @@
                     "cameraFilterKeyframes": [
                         {
                             "id": 42069, // [CameraFilterKeyframe] Camera Filter Keyframe Hold Black
-                            "filterShape": "Fullscreen",
                             "filterType": "Multiply",
-                            "fadeOutTime": 0.5
+                            "filterShape": "Fullscreen",
+                            "filterIndex": 2
                         }
                     ]
                 },
@@ -19620,6 +19637,7 @@
                             "id": 42069, // [CameraFilterKeyframe] Camera Filter Keyframe Hold Black
                             "filterShape": "Fullscreen",
                             "filterType": "Multiply",
+                            "filterIndex": 2,
                             "fadeOutTime": 0.5
                         }
                     ]
@@ -19888,6 +19906,7 @@
                             "id": 42069, // [CameraFilterKeyframe] Camera Filter Keyframe Hold Black
                             "filterShape": "Fullscreen",
                             "filterType": "Multiply",
+                            "filterIndex": 2,
                             "fadeOutTime": 0.5
                         }
                     ]
@@ -20156,6 +20175,7 @@
                             "id": 42069, // [CameraFilterKeyframe] Camera Filter Keyframe Hold Black
                             "filterShape": "Fullscreen",
                             "filterType": "Multiply",
+                            "filterIndex": 2,
                             "fadeOutTime": 0.5
                         }
                     ]
@@ -20430,6 +20450,7 @@
                             "id": 42069, // [CameraFilterKeyframe] Camera Filter Keyframe Hold Black
                             "filterShape": "Fullscreen",
                             "filterType": "Multiply",
+                            "filterIndex": 2,
                             "fadeOutTime": 0.5
                         }
                     ]
@@ -24914,6 +24935,7 @@
                             "id": 42069, // [CameraFilterKeyframe] Camera Filter Keyframe Hold Black
                             "filterShape": "Fullscreen",
                             "filterType": "Multiply",
+                            "filterIndex": 2,
                             "fadeOutTime": 0.5
                         }
                     ]
@@ -25143,6 +25165,7 @@
                             "id": 42069, // [CameraFilterKeyframe] Camera Filter Keyframe Hold Black
                             "filterShape": "Fullscreen",
                             "filterType": "Multiply",
+                            "filterIndex": 2,
                             "fadeOutTime": 0.5
                         }
                     ],
@@ -26155,6 +26178,7 @@
                             "id": 42069, // [CameraFilterKeyframe] Camera Filter Keyframe Hold Black
                             "filterShape": "Fullscreen",
                             "filterType": "Multiply",
+                            "filterIndex": 2,
                             "fadeOutTime": 0.5
                         }
                     ],
@@ -26392,6 +26416,7 @@
                             "id": 42069, // [CameraFilterKeyframe] Camera Filter Keyframe Hold Black
                             "filterShape": "Fullscreen",
                             "filterType": "Multiply",
+                            "filterIndex": 2,
                             "fadeOutTime": 0.5
                         }
                     ],
@@ -26636,6 +26661,7 @@
                             "id": 42069, // [CameraFilterKeyframe] Camera Filter Keyframe Hold Black
                             "filterShape": "Fullscreen",
                             "filterType": "Multiply",
+                            "filterIndex": 2,
                             "fadeOutTime": 0.5
                         }
                     ],
@@ -26904,6 +26930,7 @@
                             "id": 42069, // [CameraFilterKeyframe] Camera Filter Keyframe Hold Black
                             "filterShape": "Fullscreen",
                             "filterType": "Multiply",
+                            "filterIndex": 2,
                             "fadeOutTime": 0.5
                         }
                     ],
@@ -27172,6 +27199,7 @@
                             "id": 42069, // [CameraFilterKeyframe] Camera Filter Keyframe Hold Black
                             "filterShape": "Fullscreen",
                             "filterType": "Multiply",
+                            "filterIndex": 2,
                             "fadeOutTime": 0.5
                         }
                     ],
@@ -28769,6 +28797,7 @@
                             "id": 42069, // [CameraFilterKeyframe] Camera Filter Keyframe Hold Black
                             "filterShape": "Fullscreen",
                             "filterType": "Multiply",
+                            "filterIndex": 2,
                             "fadeOutTime": 0.5
                         }
                     ],
@@ -28863,6 +28892,7 @@
                             "id": 42069, // [CameraFilterKeyframe] Camera Filter Keyframe Hold Black
                             "filterShape": "Fullscreen",
                             "filterType": "Multiply",
+                            "filterIndex": 2,
                             "fadeOutTime": 0.5
                         }
                     ],


### PR DESCRIPTION
- Fixed getting blinded if skipped Transport to Phendrana Drifts South (Magmoor) arriving cutscene.
- Fixed Ventilation Shaft cutscene black bars not appearing.
- Changed Shadow Pirates in Research Entrance so they can no longer override music if both 1st and 2nd Pass layers are active when they die.
- Changed Pirates in Omega Research to now change the music on `DeathRattle` instead of `Dead`.
- Changed: [Cosmetic] The platform to Plasma Processing in Geothermal Core now immediately extends after opening the ceiling.