### PR TITLE
Fix softlock in Elite Quarters if player didn't skip OP Death cutscene.

### DIFF
--- a/generated/json_data/qol.jsonc
+++ b/generated/json_data/qol.jsonc
@@ -11936,12 +11936,57 @@
                         1705093, // [Trigger] Trigger - Play Music 2
                         1705063 // [Trigger] Trigger - Play Music 2
                     ],
+                    "removeConnections": [
+                        {
+                            "senderId": 1704898, // [Camera] camera 6-last panning shot
+                            "targetId": 1704775, // [Relay] Relay Post Pickup
+                            "state": "INACTIVE",
+                            "message": "SET_TO_ZERO"
+                        }
+                    ],
                     "addConnections": [
                         {
                             "senderId": 1703940, // [SpecialFunction] Music Player For Area
                             "targetId": 1705068, // [StreamedAudio] StreamedAudio Music Mines Dark SW
                             "state": "ENTERED",
                             "message": "PLAY"
+                        },
+                        {
+                            "senderId": 1704597, // [Relay] Relay-start of cinema
+                            "targetId": 1705171, // [PlayerHint] Player Hint Combat Visor
+                            "state": "ZERO",
+                            "message": "INCREMENT"
+                        },
+                        {
+                            "senderId": 1704898, // [Camera] camera 6-last panning shot
+                            "targetId": 1704780, // [StreamedAudio] StreamedAudio - Item Attainment SW
+                            "state": "INACTIVE",
+                            "message": "PLAY"
+                        },
+                        {
+                            "senderId": 1704898, // [Camera] camera 6-last panning shot
+                            "targetId": 1704780, // [StreamedAudio] StreamedAudio - Item Attainment SW
+                            "state": "INACTIVE",
+                            "message": "PLAY"
+                        },
+                        {
+                            "senderId": 1705156, // [SpawnPoint] Spawn point
+                            "targetId": 1703939, // [Timer] Play Music Again
+                            "state": "ZERO",
+                            "message": "START"
+                        },
+                        {
+                            "senderId": 1703939, // [Timer] Play Music Again
+                            "targetId": 1705068, // [StreamedAudio] StreamedAudio Music Mines Dark SW
+                            "state": "ZERO",
+                            "message": "PLAY"
+                        }
+                    ],
+                    "timers": [
+                        {
+                            "id": 1703939, // [Timer] Play Music Again
+                            "time": 1.0,
+                            "layer": 1
                         }
                     ],
                     "specialFunctions": [

--- a/generated/json_data/qol.jsonc
+++ b/generated/json_data/qol.jsonc
@@ -11964,12 +11964,6 @@
                             "message": "PLAY"
                         },
                         {
-                            "senderId": 1704898, // [Camera] camera 6-last panning shot
-                            "targetId": 1704780, // [StreamedAudio] StreamedAudio - Item Attainment SW
-                            "state": "INACTIVE",
-                            "message": "PLAY"
-                        },
-                        {
                             "senderId": 1705156, // [SpawnPoint] Spawn point
                             "targetId": 1703939, // [Timer] Play Music Again
                             "state": "ZERO",
@@ -11985,7 +11979,7 @@
                     "timers": [
                         {
                             "id": 1703939, // [Timer] Play Music Again
-                            "time": 1.0,
+                            "time": 2.5,
                             "layer": 1
                         }
                     ],

--- a/generated/json_data/skippable_cutscenes.jsonc
+++ b/generated/json_data/skippable_cutscenes.jsonc
@@ -22458,6 +22458,18 @@
                             "message": "INCREMENT"
                         },
                         {
+                            "senderId": 1704898, // [Camera] camera 6-last panning shot
+                            "targetId": 1704598, // [Relay] Relay-end of cinema
+                            "state": "INACTIVE",
+                            "message": "SET_TO_ZERO"
+                        },
+                        {
+                            "senderId": 1704618, // [Camera] camera 4-close up of samus busting out of back-effects
+                            "targetId": 1705068, // [StreamedAudio] StreamedAudio Music Mines Dark SW
+                            "state": "INACTIVE",
+                            "message": "PLAY"
+                        },
+                        {
                             "senderId": 1704598, // [Relay] Relay-end of cinema
                             "targetId": 1704602, // [CameraFilterKeyframe] Camera Filter Keyframe
                             "state": "ZERO",
@@ -22480,12 +22492,6 @@
                             "targetId": 1704623, // [PlayerActor] PlayerActor-omega_end_samus_breakout_cinematic
                             "state": "ZERO",
                             "message": "DEACTIVATE"
-                        },
-                        {
-                            "senderId": 1704598, // [Relay] Relay-end of cinema
-                            "targetId": 1704775, // [Relay] Relay Post Pickup
-                            "state": "ZERO",
-                            "message": "SET_TO_ZERO"
                         },
                         {
                             "senderId": 1704598, // [Relay] Relay-end of cinema
@@ -22537,6 +22543,12 @@
                         },
                         {
                             "senderId": 1704598, // [Relay] Relay-end of cinema
+                            "targetId": 1704780, // [StreamedAudio] StreamedAudio - Item Attainment SW
+                            "state": "ZERO",
+                            "message": "PLAY"
+                        },
+                        {
+                            "senderId": 1704598, // [Relay] Relay-end of cinema
                             "targetId": 1703937, // [SpecialFunction] SpecialFunction Cinematic Skip
                             "state": "ZERO",
                             "message": "DECREMENT"
@@ -22544,6 +22556,12 @@
                         {
                             "senderId": 1703937, // [SpecialFunction] SpecialFunction Cinematic Skip
                             "targetId": 1704598, // [Relay] Relay-end of cinema
+                            "state": "ZERO",
+                            "message": "SET_TO_ZERO"
+                        },
+                        {
+                            "senderId": 1703937, // [SpecialFunction] SpecialFunction Cinematic Skip
+                            "targetId": 1705156, // [SpawnPoint] Spawn point
                             "state": "ZERO",
                             "message": "SET_TO_ZERO"
                         },
@@ -22801,34 +22819,9 @@
                         },
                         {
                             "senderId": 1703937, // [SpecialFunction] SpecialFunction Cinematic Skip
-                            "targetId": 1705156, // [SpawnPoint] Spawn point
-                            "state": "ZERO",
-                            "message": "SET_TO_ZERO"
-                        },
-                        {
-                            "senderId": 1703937, // [SpecialFunction] SpecialFunction Cinematic Skip
                             "targetId": 1704618, // [Camera] camera 4-close up of samus busting out of back-effects
                             "state": "ZERO",
                             "message": "DEACTIVATE"
-                        },
-                        {
-                            "senderId": 1705156, // [SpawnPoint] Spawn point
-                            "targetId": 1703939, // [Timer] Play Music Again
-                            "state": "ZERO",
-                            "message": "START"
-                        }
-                    ],
-                    "timers": [
-                        {
-                            "id": 1703939, // [Timer] Play Music Again
-                            "time": 2.0,
-                            "layer": 1
-                        }
-                    ],
-                    "relays": [
-                        {
-                            "id": 1703938, // [Relay] PSuit Cutscene Play Music,
-                            "layer": 1
                         }
                     ],
                     "specialFunctions": [


### PR DESCRIPTION
Fixes #53 