### PR TITLE
Cutscene Skip Fixes

### DIFF
--- a/generated/json_data/skippable_cutscenes.jsonc
+++ b/generated/json_data/skippable_cutscenes.jsonc
@@ -1851,6 +1851,12 @@
                         },
                         {
                             "senderId": 1245192, // [SpecialFunction] Gate Cinematic Skip
+                            "targetId": 1245490, // [MemoryRelay] Memory Relay
+                            "state": "ZERO",
+                            "message": "ACTIVATE"
+                        },
+                        {
+                            "senderId": 1245192, // [SpecialFunction] Gate Cinematic Skip
                             "targetId": 1245760, // [SpawnPoint] Gate Spawn
                             "state": "ZERO",
                             "message": "SET_TO_ZERO"
@@ -8841,7 +8847,7 @@
                         },
                         {
                             "id": 3424927, // [Relay] End Unveil Cinematic
-                            "layer": 1
+                            "layer": 2
                         },
                         {
                             "id": 3424926, // [Relay] Flaahgra 1


### PR DESCRIPTION
- Fixed Arboretum gate not staying open on room reload if skipped the cutscene.
- Fixed Sunchamber Artifact unveil cutscene black bars not going away.