### PR TITLE
Backward MQA Lower Mines patch is also required for Wii version

### DIFF
--- a/src/patches.rs
+++ b/src/patches.rs
@@ -7825,7 +7825,7 @@ fn patch_backwards_lower_mines_mqa(
     version: Version,
 ) -> Result<(), String> {
     let scly = area.mrea().scly_section_mut();
-    let layer_id = if version == Version::Pal || version == Version::NtscJ {
+    let layer_id = if [Version::Pal, Version::NtscJ, Version::NtscJTrilogy, Version::NtscUTrilogy, Version::PalTrilogy].contains(&version) {
         7
     } else {
         0


### PR DESCRIPTION
Fixes backward lower mines support for Wii version in Metroid Quarantine A