### PR TITLE
Music tweaks and Phazon Elite softlock fix

### DIFF
--- a/generated/json_data/qol.jsonc
+++ b/generated/json_data/qol.jsonc
@@ -3072,7 +3072,31 @@
                             "message": "PLAY"
                         },
                         {
+                            "senderId": 131088, // [SpecialFunction] Music Player For Area
+                            "targetId": 131092, // [Relay] Allow Replay
+                            "state": "ENTERED",
+                            "message": "ACTIVATE"
+                        },
+                        {
+                            "senderId": 131088, // [SpecialFunction] Music Player For Area
+                            "targetId": 132989, // [Timer] Disallow Replay
+                            "state": "ENTERED",
+                            "message": "RESET_AND_START"
+                        },
+                        {
+                            "senderId": 132989, // [Timer] Disallow Replay
+                            "targetId": 131092, // [Relay] Allow Replay
+                            "state": "ZERO",
+                            "message": "DEACTIVATE"
+                        },
+                        {
                             "senderId": 131724, // [Timer] Timer - Fade In Music
+                            "targetId": 131092, // [Relay] Allow Replay
+                            "state": "ZERO",
+                            "message": "SET_TO_ZERO"
+                        },
+                        {
+                            "senderId": 131092, // [Relay] Allow Replay
                             "targetId": 131091, // [StreamedAudio] StreamedAudio - Ruins Soto B SW
                             "state": "ZERO",
                             "message": "PLAY"
@@ -3082,6 +3106,20 @@
                         {
                             "id": 131088, // [SpecialFunction] Music Player For Area
                             "type": "PlayerInAreaRelay"
+                        }
+                    ],
+                    "relays": [
+                        {
+                            "id": 131092, // [Relay] Allow Replay
+                            "layer": 5,
+                            "active": false
+                        }
+                    ],
+                    "timers": [
+                        {
+                            "id": 132989, // [Timer] Disallow Replay
+                            "time": 1.5,
+                            "layer": 5
                         }
                     ],
                     "streamedAudios": [
@@ -3287,10 +3325,24 @@
                 "Plaza Access": {
                     "addConnections": [
                         {
+                            "senderId": 393538, // [Timer] Music Player For Area
+                            "targetId": 393236, // [SpecialFunction] Music Player For Area
+                            "state": "ZERO",
+                            "message": "ACTION"
+                        },
+                        {
                             "senderId": 393236, // [SpecialFunction] Music Player For Area
                             "targetId": 393237, // [StreamedAudio] StreamedAudio - Ruins Samus SW
-                            "state": "ENTERED",
+                            "state": "ZERO",
                             "message": "PLAY"
+                        }
+                    ],
+                    "timers": [
+                        {
+                            "id": 393538, // [Timer] Music Player For Area
+                            "time": 0.02,
+                            "looping": true,
+                            "startImmediately": true
                         }
                     ],
                     "specialFunctions": [

--- a/generated/json_data/qol.jsonc
+++ b/generated/json_data/qol.jsonc
@@ -2795,75 +2795,45 @@
                     "addConnections": [
                         {
                             "senderId": 4507917, // [SpecialFunction] Music Player For Area
-                            "targetId": 3489927, // [Relay] Play Hall of the Elders
+                            "targetId": 3489927, // [Switch] OPEN: Hall of the Elders / CLOSED: Ghosts
                             "state": "ENTERED",
                             "message": "SET_TO_ZERO"
                         },
                         {
-                            "senderId": 4507917, // [SpecialFunction] Music Player For Area
-                            "targetId": 3485962, // [Relay] Play Chozo Ghosts
-                            "state": "ENTERED",
-                            "message": "SET_TO_ZERO"
-                        },
-                        {
-                            "senderId": 3489927, // [Relay] Play Hall of the Elders
+                            "senderId": 3489927, // [Switch] OPEN: Hall of the Elders / CLOSED: Ghosts
                             "targetId": 3408663, // [StreamedAudio] StreamedAudio - Music Ruins Chozobowling SW
-                            "state": "ZERO",
+                            "state": "OPEN",
                             "message": "PLAY"
                         },
                         {
-                            "senderId": 3485962, // [Relay] Play Chozo Ghosts
+                            "senderId": 3489927, // [Switch] OPEN: Hall of the Elders / CLOSED: Ghosts
                             "targetId": 3408566, // [StreamedAudio] StreamedAudio - General ShortBattle 2 SW
-                            "state": "ZERO",
+                            "state": "CLOSED",
                             "message": "PLAY"
                         },
                         {
                             "senderId": 3408130, // [Trigger] Trigger-Chozo Ghost
-                            "targetId": 3489927, // [Relay] Play Hall of the Elders
+                            "targetId": 3489927, // [Switch] OPEN: Hall of the Elders / CLOSED: Ghosts
                             "state": "ENTERED",
-                            "message": "DEACTIVATE"
-                        },
-                        {
-                            "senderId": 3408130, // [Trigger] Trigger-Chozo Ghost
-                            "targetId": 3485962, // [Relay] Play Chozo Ghosts
-                            "state": "ENTERED",
-                            "message": "ACTIVATE"
+                            "message": "CLOSE"
                         },
                         {
                             "senderId": 3407887, // [ChozoGhost] ChozoGhost
-                            "targetId": 3489927, // [Relay] Play Hall of the Elders
+                            "targetId": 3489927, // [Switch] OPEN: Hall of the Elders / CLOSED: Ghosts
                             "state": "DEAD",
-                            "message": "ACTIVATE"
-                        },
-                        {
-                            "senderId": 3407887, // [ChozoGhost] ChozoGhost
-                            "targetId": 3485962, // [Relay] Play Chozo Ghosts
-                            "state": "DEAD",
-                            "message": "DEACTIVATE"
+                            "message": "OPEN"
                         },
                         {
                             "senderId": 3408399, // [Trigger] Trigger - Chozo Ghost No Kaishi
-                            "targetId": 3489927, // [Relay] Play Hall of the Elders
+                            "targetId": 3489927, // [Switch] OPEN: Hall of the Elders / CLOSED: Ghosts
                             "state": "ENTERED",
-                            "message": "DEACTIVATE"
-                        },
-                        {
-                            "senderId": 3408399, // [Trigger] Trigger - Chozo Ghost No Kaishi
-                            "targetId": 3485962, // [Relay] Play Chozo Ghosts
-                            "state": "ENTERED",
-                            "message": "ACTIVATE"
+                            "message": "CLOSE"
                         },
                         {
                             "senderId": 3408401, // [Counter] Counter_Dead Chozo
-                            "targetId": 3489927, // [Relay] Play Hall of the Elders
+                            "targetId": 3489927, // [Switch] OPEN: Hall of the Elders / CLOSED: Ghosts
                             "state": "MAX_REACHED",
-                            "message": "ACTIVATE"
-                        },
-                        {
-                            "senderId": 3408401, // [Counter] Counter_Dead Chozo
-                            "targetId": 3485962, // [Relay] Play Chozo Ghosts
-                            "state": "MAX_REACHED",
-                            "message": "DEACTIVATE"
+                            "message": "OPEN"
                         },
                         {
                             "senderId": 3408624, // [Trigger] Trigger - Play Music Recharge - Recharge
@@ -2873,9 +2843,9 @@
                         },
                         {
                             "senderId": 3408624, // [Trigger] Trigger - Play Music Recharge - Recharge
-                            "targetId": 3408663, // [StreamedAudio] StreamedAudio - Music Ruins Chozobowling SW
+                            "targetId": 3489927, // [Switch] OPEN: Hall of the Elders / CLOSED: Ghosts
                             "state": "EXITED",
-                            "message": "PLAY"
+                            "message": "SET_TO_ZERO"
                         }
                     ],
                     "specialFunctions": [
@@ -2884,13 +2854,10 @@
                             "type": "PlayerInAreaRelay"
                         }
                     ],
-                    "relays": [
+                    "switches": [
                         {
-                            "id": 3489927 // [Relay] Play Hall of the Elders
-                        },
-                        {
-                            "id": 3485962, // [Relay] Play Chozo Ghosts
-                            "active": false
+                            "id": 3489927, // [Switch] OPEN: Hall of the Elders / CLOSED: Ghosts
+                            "open": true
                         }
                     ],
                     "triggers": [
@@ -3102,6 +3069,12 @@
                             "senderId": 131088, // [SpecialFunction] Music Player For Area
                             "targetId": 131091, // [StreamedAudio] StreamedAudio - Ruins Soto B SW
                             "state": "ENTERED",
+                            "message": "PLAY"
+                        },
+                        {
+                            "senderId": 131724, // [Timer] Timer - Fade In Music
+                            "targetId": 131091, // [StreamedAudio] StreamedAudio - Ruins Soto B SW
+                            "state": "ZERO",
                             "message": "PLAY"
                         }
                     ],
@@ -5155,10 +5128,58 @@
                             "message": "ACTION"
                         },
                         {
+                            "senderId": 1599653, // [Timer] Music Player For Area
+                            "targetId": 1179653, // [SpecialFunction] Music Player For Area
+                            "state": "ZERO",
+                            "message": "ACTION"
+                        },
+                        {
                             "senderId": 1179653, // [SpecialFunction] Music Player For Area
-                            "targetId": 1179658, // [StreamedAudio] StreamedAudio - Ruins Samus SW
+                            "targetId": 1179658, // [StreamedAudio] StreamedAudio - Ruins Samus SW (No Fade)
                             "state": "ZERO",
                             "message": "PLAY"
+                        },
+                        {
+                            "senderId": 1179653, // [SpecialFunction] Music Player For Area
+                            "targetId": 1179798, // [StreamedAudio] StreamedAudio - Ruins Samus SW (Long Fade for Pickup)
+                            "state": "ZERO",
+                            "message": "PLAY"
+                        },
+                        {
+                            "senderId": 1179653, // [SpecialFunction] Music Player For Area
+                            "targetId": 1179798, // [StreamedAudio] StreamedAudio - Ruins Samus SW (Long Fade for Pickup)
+                            "state": "EXITED",
+                            "message": "DEACTIVATE"
+                        },
+                        {
+                            "senderId": 1179653, // [SpecialFunction] Music Player For Area
+                            "targetId": 1179658, // [StreamedAudio] StreamedAudio - Ruins Samus SW (No Fade)
+                            "state": "EXITED",
+                            "message": "ACTIVATE"
+                        },
+                        {
+                            "senderId": 1179719, // [Relay] Relay - Fade Out Music
+                            "targetId": 1599653, // [Timer] Music Player For Area
+                            "state": "ZERO",
+                            "message": "STOP"
+                        },
+                        {
+                            "senderId": 1179720, // [Timer] Timer - Fade In Music
+                            "targetId": 1599653, // [Timer] Music Player For Area
+                            "state": "ZERO",
+                            "message": "START"
+                        },
+                        {
+                            "senderId": 1179708, // [Trigger] Trigger_normal
+                            "targetId": 1179658, // [StreamedAudio] StreamedAudio - Ruins Samus SW (No Fade)
+                            "state": "ENTERED",
+                            "message": "DEACTIVATE"
+                        },
+                        {
+                            "senderId": 1179708, // [Trigger] Trigger_normal
+                            "targetId": 1179798, // [StreamedAudio] StreamedAudio - Ruins Samus SW (Long Fade for Pickup)
+                            "state": "ENTERED",
+                            "message": "ACTIVATE"
                         }
                     ],
                     "specialFunctions": [
@@ -5170,17 +5191,25 @@
                     "timers": [
                         {
                             "id": 1599653, // [Timer] Music Player For Area
-                            "time": 0.001,
+                            "time": 0.02,
                             "looping": true,
                             "startImmediately": true
                         }
                     ],
                     "streamedAudios": [
                         {
-                            "id": 1179658, // [StreamedAudio] StreamedAudio - Ruins Samus SW
+                            "id": 1179658, // [StreamedAudio] StreamedAudio - Ruins Samus SW (No Fade)
                             "volume": 70,
                             "isMusic": true,
                             "fadeInTime": 0.01,
+                            "audioFileName": "/audio/rui_samusL.dsp|/audio/rui_samusR.dsp"
+                        },
+                        {
+                            "id": 1179798, // [StreamedAudio] StreamedAudio - Ruins Samus SW (Long Fade for Pickup)
+                            "active": false,
+                            "volume": 70,
+                            "isMusic": true,
+                            "fadeInTime": 2.0,
                             "audioFileName": "/audio/rui_samusL.dsp|/audio/rui_samusR.dsp"
                         }
                     ]

--- a/generated/json_data/skippable_cutscenes.jsonc
+++ b/generated/json_data/skippable_cutscenes.jsonc
@@ -22956,6 +22956,54 @@
                             "targetId": 852702, // [CameraFilterKeyframe] Camera Filter Keyframe Widescreen
                             "state": "INACTIVE",
                             "message": "DECREMENT"
+                        },
+                        {
+                            "senderId": 852393, // [Timer] Timer_Break Tank
+                            "targetId": 852418, // [Timer] Timer Alert Elite
+                            "state": "ZERO",
+                            "message": "RESET_AND_START"
+                        },
+                        {
+                            "senderId": 852393, // [Timer] Timer_Break Tank
+                            "targetId": 852419, // [CameraShaker] CameraShaker_Breaktank
+                            "state": "ZERO",
+                            "message": "ACTION"
+                        },
+                        {
+                            "senderId": 852393, // [Timer] Timer_Break Tank
+                            "targetId": 852420, // [Sound] Sound
+                            "state": "ZERO",
+                            "message": "PLAY"
+                        },
+                        {
+                            "senderId": 852393, // [Timer] Timer_Break Tank
+                            "targetId": 852433, // [Generator] Generator_Shards
+                            "state": "ZERO",
+                            "message": "SET_TO_ZERO"
+                        },
+                        {
+                            "senderId": 852393, // [Timer] Timer_Break Tank
+                            "targetId": 852460, // [Sound] Sound_Eliteshout
+                            "state": "ZERO",
+                            "message": "PLAY"
+                        },
+                        {
+                            "senderId": 852393, // [Timer] Timer_Break Tank
+                            "targetId": 852820, // [MemoryRelay] Memory Relay - Kill Elite Pirate Tank Sound
+                            "state": "ZERO",
+                            "message": "ACTIVATE"
+                        },
+                        {
+                            "senderId": 852393, // [Timer] Timer_Break Tank
+                            "targetId": 852214, // [Platform] Platform_holding Tank
+                            "state": "ZERO",
+                            "message": "DEACTIVATE"
+                        },
+                        {
+                            "senderId": 852393, // [Timer] Timer_Break Tank
+                            "targetId": 852507, // [Effect] Effect
+                            "state": "ZERO",
+                            "message": "ACTIVATE"
                         }
                     ],
                     "addConnections": [
@@ -22966,20 +23014,74 @@
                             "message": "SET_TO_ZERO"
                         },
                         {
-                            "senderId": 852214, // [Platform] Platform_holding Tank
-                            "targetId": 852471, // [PointOfInterest] POI_03_Mines panel 1.scan
-                            "state": "DEAD",
-                            "message": "DEACTIVATE"
+                            "senderId": 852393, // [Timer] Timer_Break Tank
+                            "targetId": 851989, // [Relay] Break Tank Relay
+                            "state": "ZERO",
+                            "message": "SET_TO_ZERO"
                         },
                         {
-                            "senderId": 852388, // [ElitePirate] ElitePirate
-                            "targetId": 852471, // [PointOfInterest] POI_03_Mines panel 1.scan
-                            "state": "DEAD",
+                            "senderId": 851989, // [Relay] Break Tank Relay
+                            "targetId": 851990, // [Relay] Break Tank Relay Deactivate
+                            "state": "ZERO",
+                            "message": "SET_TO_ZERO"
+                        },
+                        {
+                            "senderId": 851989, // [Relay] Break Tank Relay
+                            "targetId": 852419, // [CameraShaker] CameraShaker_Breaktank
+                            "state": "ZERO",
+                            "message": "ACTION"
+                        },
+                        {
+                            "senderId": 851989, // [Relay] Break Tank Relay
+                            "targetId": 852420, // [Sound] Sound
+                            "state": "ZERO",
+                            "message": "PLAY"
+                        },
+                        {
+                            "senderId": 851989, // [Relay] Break Tank Relay
+                            "targetId": 852433, // [Generator] Generator_Shards
+                            "state": "ZERO",
+                            "message": "SET_TO_ZERO"
+                        },
+                        {
+                            "senderId": 851989, // [Relay] Break Tank Relay
+                            "targetId": 852460, // [Sound] Sound_Eliteshout
+                            "state": "ZERO",
+                            "message": "PLAY"
+                        },
+                        {
+                            "senderId": 851989, // [Relay] Break Tank Relay
+                            "targetId": 852820, // [MemoryRelay] Memory Relay - Kill Elite Pirate Tank Sound
+                            "state": "ZERO",
                             "message": "ACTIVATE"
                         },
                         {
+                            "senderId": 851989, // [Relay] Break Tank Relay
+                            "targetId": 852214, // [Platform] Platform_holding Tank
+                            "state": "ZERO",
+                            "message": "DEACTIVATE"
+                        },
+                        {
+                            "senderId": 851989, // [Relay] Break Tank Relay
+                            "targetId": 852507, // [Effect] Effect
+                            "state": "ZERO",
+                            "message": "ACTIVATE"
+                        },
+                        {
+                            "senderId": 851990, // [Relay] Break Tank Relay Deactivate
+                            "targetId": 851989, // [Relay] Break Tank Relay
+                            "state": "ZERO",
+                            "message": "DEACTIVATE"
+                        },
+                        {
+                            "senderId": 851989, // [Relay] Break Tank Relay
+                            "targetId": 852418, // [Timer] Timer Alert Elite
+                            "state": "ZERO",
+                            "message": "RESET_AND_START"
+                        },
+                        {
                             "senderId": 851971, // [Relay] Breakout Cutscene Start
-                            "targetId": 851973, // [SpecialFunction] SpecialFunction Cinematic Skip
+                            "targetId": 851973, // [SpecialFunction] Breakout Cinematic Skip
                             "state": "ZERO",
                             "message": "INCREMENT"
                         },
@@ -23009,7 +23111,7 @@
                         },
                         {
                             "senderId": 851972, // [Relay] Breakout Cutscene End
-                            "targetId": 851973, // [SpecialFunction] SpecialFunction Cinematic Skip
+                            "targetId": 851973, // [SpecialFunction] Breakout Cinematic Skip
                             "state": "ZERO",
                             "message": "DECREMENT"
                         },
@@ -23020,106 +23122,22 @@
                             "message": "SET_TO_ZERO"
                         },
                         {
-                            "senderId": 851973, // [SpecialFunction] SpecialFunction Cinematic Skip
+                            "senderId": 851973, // [SpecialFunction] Breakout Cinematic Skip
                             "targetId": 851972, // [Relay] Breakout Cutscene End
                             "state": "ZERO",
                             "message": "SET_TO_ZERO"
                         },
                         {
-                            "senderId": 851973, // [SpecialFunction] SpecialFunction Cinematic Skip
+                            "senderId": 851973, // [SpecialFunction] Breakout Cinematic Skip
                             "targetId": 853011, // [Camera] Cinematic Camera
                             "state": "ZERO",
                             "message": "DEACTIVATE"
                         },
                         {
-                            "senderId": 851973, // [SpecialFunction] SpecialFunction Cinematic Skip
-                            "targetId": 851974, // [Relay] Cinematic Skip Break Tank
+                            "senderId": 851973, // [SpecialFunction] Breakout Cinematic Skip
+                            "targetId": 851989, // [Relay] Break Tank Relay
                             "state": "ZERO",
                             "message": "SET_TO_ZERO"
-                        },
-                        {
-                            "senderId": 851973, // [SpecialFunction] SpecialFunction Cinematic Skip
-                            "targetId": 852393, // [Timer] Timer_Break Tank
-                            "state": "ZERO",
-                            "message": "STOP"
-                        },
-                        {
-                            "senderId": 851973, // [SpecialFunction] SpecialFunction Cinematic Skip
-                            "targetId": 852418, // [Timer] Timer Alert Elite
-                            "state": "ZERO",
-                            "message": "STOP"
-                        },
-                        {
-                            "senderId": 851974, // [Relay] Cinematic Skip Break Tank
-                            "targetId": 852419, // [CameraShaker] CameraShaker_Breaktank
-                            "state": "ZERO",
-                            "message": "ACTION"
-                        },
-                        {
-                            "senderId": 851974, // [Relay] Cinematic Skip Break Tank
-                            "targetId": 852420, // [Sound] Sound
-                            "state": "ZERO",
-                            "message": "PLAY"
-                        },
-                        {
-                            "senderId": 851974, // [Relay] Cinematic Skip Break Tank
-                            "targetId": 852433, // [Generator] Generator_Shards
-                            "state": "ZERO",
-                            "message": "SET_TO_ZERO"
-                        },
-                        {
-                            "senderId": 851974, // [Relay] Cinematic Skip Break Tank
-                            "targetId": 852820, // [MemoryRelay] Memory Relay - Kill Elite Pirate Tank Sound
-                            "state": "ZERO",
-                            "message": "ACTIVATE"
-                        },
-                        {
-                            "senderId": 851974, // [Relay] Cinematic Skip Break Tank
-                            "targetId": 852214, // [Platform] Platform_holding Tank
-                            "state": "ZERO",
-                            "message": "DEACTIVATE"
-                        },
-                        {
-                            "senderId": 851974, // [Relay] Cinematic Skip Break Tank
-                            "targetId": 852507, // [Effect] Effect
-                            "state": "ZERO",
-                            "message": "ACTIVATE"
-                        },
-                        {
-                            "senderId": 851974, // [Relay] Cinematic Skip Break Tank
-                            "targetId": 852388, // [ElitePirate] ElitePirate
-                            "state": "ZERO",
-                            "message": "ACTIVATE"
-                        },
-                        {
-                            "senderId": 851974, // [Relay] Cinematic Skip Break Tank
-                            "targetId": 852391, // [Actor] Actor Dummy Pirate Bustout
-                            "state": "ZERO",
-                            "message": "DEACTIVATE"
-                        },
-                        {
-                            "senderId": 851974, // [Relay] Cinematic Skip Break Tank
-                            "targetId": 852998, // [Relay] Relay Enable Lock (To Trigger_Unlock&Key With Increment)
-                            "state": "ZERO",
-                            "message": "SET_TO_ZERO"
-                        },
-                        {
-                            "senderId": 851974, // [Relay] Cinematic Skip Break Tank
-                            "targetId": 853227, // [Timer] Timer_Alert Elite
-                            "state": "ZERO",
-                            "message": "RESET_AND_START"
-                        },
-                        {
-                            "senderId": 851974, // [Relay] Cinematic Skip Break Tank
-                            "targetId": 852460, // [Sound] Sound_Eliteshout
-                            "state": "ZERO",
-                            "message": "PLAY"
-                        },
-                        {
-                            "senderId": 852393, // [Timer] Timer_Break Tank
-                            "targetId": 851974, // [Relay] Cinematic Skip Break Tank
-                            "state": "ZERO",
-                            "message": "DEACTIVATE"
                         },
                         {
                             "senderId": 852388, // [ElitePirate] ElitePirate
@@ -23442,13 +23460,20 @@
                     ],
                     "relays": [
                         {
-                            "id": 851971 // [Relay] Breakout Cutscene Start
+                            "id": 851971, // [Relay] Breakout Cutscene Start
+                            "layer": 1
                         },
                         {
-                            "id": 851972 // [Relay] Breakout Cutscene End
+                            "id": 851972, // [Relay] Breakout Cutscene End
+                            "layer": 1
                         },
                         {
-                            "id": 851974 // [Relay] Cinematic Skip Break Tank
+                            "id": 851990, // [Relay] Break Tank Relay Deactivate
+                            "layer": 1
+                        },
+                        {
+                            "id": 851989, // [Relay] Break Tank Relay
+                            "layer": 1
                         },
                         {
                             "id": 851975 // [Relay] Artifact Reveal Start
@@ -23483,8 +23508,9 @@
                     ],
                     "specialFunctions": [
                         {
-                            "id": 851973, // [SpecialFunction] SpecialFunction Cinematic Skip
-                            "type": "CinematicSkip"
+                            "id": 851973, // [SpecialFunction] Breakout Cinematic Skip
+                            "type": "CinematicSkip",
+                            "layer": 1
                         },
                         {
                             "id": 851977, // [SpecialFunction] SpecialFunction Cinematic Skip


### PR DESCRIPTION
- Fixed audio Fade In/Outs overriding music changes between rooms for certain areas.
- Elite Research
  - Fixed a frame perfect cutscene skip issue causing Phazon Elite to forever be idle after breaking out of his tank.
  - Removed platforms scan prevention patch as there is already a dedicated patch for it.