### PR TITLE
Adjust Main Menu seed info text

### DIFF
--- a/src/patches.rs
+++ b/src/patches.rs
@@ -9792,8 +9792,8 @@ fn patch_main_menu(res: &mut structs::Resource) -> Result<(), String> {
         kind: structs::FrmeWidgetKind::TextPane(structs::TextPaneWidget {
             x_dim: 10.455326,
             z_dim: 1.813613,
-            scale_center: [-5.227663, 0.0, -0.51].into(),
-            font: resource_info!("Deface14B_O.FONT").try_into().unwrap(),
+            scale_center: [-25.227663, 0.0, -4.43].into(),
+            font: resource_info!("Deface13B.FONT").try_into().unwrap(),
             word_wrap: 0,
             horizontal: 1,
             justification: 0,
@@ -9805,7 +9805,7 @@ fn patch_main_menu(res: &mut structs::Resource) -> Result<(), String> {
             jpn_point_scale,
         }),
         worker_id: None,
-        origin: [9.25, 1.500001, 0.0].into(),
+        origin: [24.6, 1.500001, 0.3].into(),
         basis: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0].into(),
         rotation_center: [0.0, 0.0, 0.0].into(),
         unknown0: 0,
@@ -9820,9 +9820,9 @@ fn patch_main_menu(res: &mut structs::Resource) -> Result<(), String> {
     };
     tp.fill_color = [0.0, 0.0, 0.0, 0.4].into();
     tp.outline_color = [0.0, 0.0, 0.0, 0.2].into();
-    shadow_widget.origin[0] -= -0.235091;
-    shadow_widget.origin[1] -= -0.104353;
-    shadow_widget.origin[2] -= 0.176318;
+    shadow_widget.origin[0] -= -0.1;
+    shadow_widget.origin[1] -= -0.1;
+    shadow_widget.origin[2] -= 0.1;
 
     frme.widgets.as_mut_vec().push(shadow_widget);
 


### PR DESCRIPTION
New position, smaller font to give room for bigger words
# NTSC
<img width="1920" height="1447" alt="GM8E01_2025-07-25_22-59-14" src="https://github.com/user-attachments/assets/b23046fc-a8b3-43a3-9e09-f07fb5700b8b" />

#  PAL
<img width="1920" height="1447" alt="GM8P01_2025-07-25_22-59-23" src="https://github.com/user-attachments/assets/e1b0b2c0-e4cd-4888-af56-80fff7e95e50" />
