### PR TITLE
Fix Player sometimes not having controls in Metroid Prime Lair

### DIFF
--- a/generated/json_data/skippable_cutscenes.jsonc
+++ b/generated/json_data/skippable_cutscenes.jsonc
@@ -28612,6 +28612,9 @@
                     ]
                 },
                 "Subchamber Five": {
+                    "deleteIds": [
+                        721370
+                    ],
                     "removeConnections": [
                         {
                             "senderId": 655378, // [Camera] Cinematic Camera1
@@ -28781,10 +28784,6 @@
                         {
                             "id": 655396, // [SpecialFunction] SpecialFunction Cinematic Skip
                             "type": "CinematicSkip"
-                        },
-                        {
-                            "id": 655435, // [SpecialFunction] PlayerInArea
-                            "type": "PlayerInAreaRelay"
                         }
                     ]
                 },
@@ -28993,8 +28992,7 @@
                         },
                         {
                             "id": 721075, // [Timer] Disable Failsafe
-                            "time": 0.5,
-                            "startImmediately": true
+                            "time": 0.5
                         }
                     ],
                     "streamedAudios": [


### PR DESCRIPTION
If Metroid Prime Lair finishes loading before the Subchamber Five cutscene is finished (I.E Nintendont and the player does not skip cutscene immediately) the scan visor crash failsafe check where control is temporarely taken away from the player would not fire, because the timer was wrongfully set to start immediately. So the timer would run out, then the player would transition to Metroid Prime Lair where **THEN** the No Control PlayerHint would fire and start the timer, but the timer has already been fired, so player remains without control forever.