### PR TITLE
Skippable Cutscenes - Fix docile Beta Beetle in Ruined Shrine

### DIFF
--- a/generated/json_data/build.rs
+++ b/generated/json_data/build.rs
@@ -4,6 +4,8 @@ use json_strip::strip_jsonc_comments;
 use minify::json::minify;
 
 fn helper(filename: &'static str) {
+    println!("cargo:rerun-if-changed={}", filename);
+
     let out_dir = env::var("OUT_DIR").unwrap();
     let out_dir = Path::new(&out_dir);
 

--- a/generated/json_data/skippable_cutscenes.jsonc
+++ b/generated/json_data/skippable_cutscenes.jsonc
@@ -6900,12 +6900,6 @@
                         },
                         {
                             "senderId": 589930, // [Relay] Relay - end of cinema
-                            "targetId": 589944, // [Beetle] GarBeetle
-                            "state": "ZERO",
-                            "message": "RESET"
-                        },
-                        {
-                            "senderId": 589930, // [Relay] Relay - end of cinema
                             "targetId": 590117, // [CameraFilterKeyframe] Camera Filter Keyframe
                             "state": "ZERO",
                             "message": "DEACTIVATE"
@@ -7011,6 +7005,58 @@
                             "targetId": 590117, // [CameraFilterKeyframe] Camera Filter Keyframe
                             "state": "ZERO",
                             "message": "ACTIVATE"
+                        },
+                        // randomprime beetle spawns simultaneously with vanilla beetle, then despawns 0.65s after
+                        {
+                            "senderId": 589836, // [Timer] Start Beta Beetle
+                            "targetId": 651384, // [Beetle] GarBeetle (randomprime, no intro animation)
+                            "state": "ZERO",
+                            "message": "ACTIVATE"
+                        },
+                        {
+                            "senderId": 589836, // [Timer] Start Beta Beetle
+                            "targetId": 651387, // [Timer] Deactivate randomprime beetle
+                            "state": "ZERO",
+                            "message": "RESET_AND_START"
+                        },
+                        {
+                            "senderId": 651387, // [Timer] Deactivate randomprime beetle
+                            "targetId": 651384, // [Beetle] GarBeetle (randomprime, no intro animation)
+                            "state": "ZERO",
+                            "message": "DEACTIVATE"
+                        },
+                        // skipping the cutscene early stops the randomprime beetle despawn
+                        {
+                            "senderId": 589932, // [SpecialFunction] beta reveal Cinematic Skip
+                            "targetId": 651387, // [Timer] Deactivate randomprime beetle
+                            "state": "ZERO",
+                            "message": "DEACTIVATE"
+                        },
+                        // skipping the cutscene deactivates vanilla beetle and reactivates randomprime beetle on the same frame
+                        {
+                            "senderId": 589932, // [SpecialFunction] beta reveal Cinematic Skip
+                            "targetId": 589944, // [Beetle] GarBeetle (vanilla)
+                            "state": "ZERO",
+                            "message": "DEACTIVATE"
+                        },
+                        {
+                            "senderId": 589932, // [SpecialFunction] beta reveal Cinematic Skip
+                            "targetId": 651384, // [Beetle] GarBeetle (randomprime, no intro animation)
+                            "state": "ZERO",
+                            "message": "ACTIVATE"
+                        },
+                        // Cutscene skip is disabled for the last 1.1s of the cutscene
+                        {
+                            "senderId": 590084, // [Camera] Camera3 (last beta-reveal shot, 3s)
+                            "targetId": 651386, // [Timer] Disable CS Skip
+                            "state": "ACTIVE",
+                            "message": "RESET_AND_START"
+                        },
+                        {
+                            "senderId": 651386, // [Timer] Disable CS Skip
+                            "targetId": 589932, // [SpecialFunction] beta reveal Cinematic Skip
+                            "state": "ZERO",
+                            "message": "DECREMENT"
                         }
                     ],
                     "relays": [
@@ -7045,6 +7091,14 @@
                         {
                             "id": 789829, // [Timer] Re-Enable Black Bars
                             "time": 0.03
+                        },
+                        {
+                            "id": 651386, // [Timer] Disable CS Skip - 1.9s into Camera3 (3s) = final 1.1s
+                            "time": 1.9
+                        },
+                        {
+                            "id": 651387, // [Timer] Deactivate randomprime beetle
+                            "time": 0.65
                         }
                     ],
                     "lockOnPoints": [

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -6013,6 +6013,41 @@ fn patch_add_cutscene_skip_fn(
     Ok(())
 }
 
+fn patch_ruined_shrine_beetle_swap(
+    _ps: &mut PatcherState,
+    area: &mut mlvl_wrapper::MlvlArea,
+) -> Result<(), String> {
+    const RUINED_SHRINE_BEETLE: u32 = 0x00090078;
+    const RUINED_SHRINE_BEETLE_DUP: u32 = 0x0009F078;
+
+    let layers = area.mrea().scly_section_mut().layers.as_mut_vec();
+
+    let mut found: Option<(usize, structs::SclyObject)> = None;
+    for (i, layer) in layers.iter_mut().enumerate() {
+        let obj = layer
+            .objects
+            .as_mut_vec()
+            .iter()
+            .find(|o| o.instance_id & 0x00FFFFFF == RUINED_SHRINE_BEETLE);
+        if let Some(obj) = obj {
+            let mut dup = obj.clone();
+            dup.instance_id = (obj.instance_id & 0xFF000000) | RUINED_SHRINE_BEETLE_DUP;
+            if let Some(beetle) = dup.property_data.as_beetle_mut() {
+                beetle.entrance_type = 0.0; // kET_FacePlayer
+                beetle.patterned_info.active = 0; // dormant until the swap activates it
+                beetle.position = [-60.34137, 3.246905, -0.101854].into();
+            }
+            found = Some((i, dup));
+            break;
+        }
+    }
+
+    let (layer_idx, dup) = found.ok_or("Ruined Shrine beetle 0x090078 not found")?;
+    layers[layer_idx].objects.as_mut_vec().push(dup);
+
+    Ok(())
+}
+
 pub fn string_to_cstr<'r>(string: String) -> CStr<'r> {
     let x = CString::new(string).expect("CString conversion failed");
     let x = Cow::Owned(x);
@@ -15921,6 +15956,13 @@ fn build_and_run_patches<'r>(
                                         move |ps, area| {
                                             patch_artifact_temple_pillar(ps, area, 1048911)
                                         },
+                                    );
+                                }
+                                0x3C785450 => {
+                                    // Ruined Shrine
+                                    patcher.add_scly_patch(
+                                        (pak_name.as_bytes(), room_info.room_id.to_u32()),
+                                        patch_ruined_shrine_beetle_swap,
                                     );
                                 }
                                 _ => {}


### PR DESCRIPTION
# Issue

The Ruined Shrine 1st pass Beta Beetle instance is unique in that it has a long startup animation that plays while the cutscene observe the beetle. Since randomprime patches the cutscene to make it skippable, the player can have control while the animation still has 5+ seconds of time remaining, making the fight trivial.

# Fix

The cutscene is patched to follow this new sequence:

1. All Alpha Beetles dead and Beta beetle cutscene starts
2. When the Beta beetle spawns, spawn a second one simultaneously at the exact same position. This duplicate beetle is identical except that it does not have the long docile startup animation.
3. 0.65s after the Beetles have spawned (just enough time for them to un-burrow), disable the copy.
4. If the cutscene is skipped, deactivate the cutscene beetle and reactivate the copy. The copy will aggro the player immediately
5. If the cutscene is not skipped, the beetle will finish it's animation as normal

Notes:
- The last 1.1s of the cutscene disables the option to skip to avoid race conditions
- There is still a slight divergence in behavior. Un-skipped cutscene does one left-right dance before the first charge, skipped cutscene will perform first charge immediately.
- Very observant people may notice the two beetles for the few tenths of a second they are both on screen (shown in slowmo at end of video)

# Validation

- Validate all 6 GC game versions patch with `SkippableCompetitive` cutscene skips enabled
- Recorded the following video on NTSC 0-00

https://github.com/user-attachments/assets/2fc479b9-5c21-442c-a6eb-3ae2edf557ac

