### PR TITLE
Fix double-free cutscene crash

### DIFF
--- a/src/add_modify_obj_patches.rs
+++ b/src/add_modify_obj_patches.rs
@@ -10,12 +10,11 @@ use crate::{
     patch_config::{
         ActorKeyframeConfig, ActorRotateConfig, BallTriggerConfig, BlockConfig, BombSlotConfig,
         CameraConfig, CameraFilterKeyframeConfig, CameraHintTriggerConfig, CameraWaypointConfig,
-        ControllerActionConfig, CounterConfig, DamageType, FilterShape, FilterType,
-        FogConfig, GenericTexture, HudmemoConfig, InitialSplinePosition, LockOnPoint,
-        NewCameraHintConfig, PathCameraConfig, PlatformConfig, PlatformType, PlayerActorConfig,
-        PlayerHintConfig, RelayConfig, SpawnPointConfig, SpecialFunctionConfig,
-        StreamedAudioConfig, SwitchConfig, TimerConfig, TriggerConfig, WaterConfig, WaypointConfig,
-        WorldLightFaderConfig,
+        ControllerActionConfig, CounterConfig, DamageType, FilterShape, FilterType, FogConfig,
+        GenericTexture, HudmemoConfig, InitialSplinePosition, LockOnPoint, NewCameraHintConfig,
+        PathCameraConfig, PlatformConfig, PlatformType, PlayerActorConfig, PlayerHintConfig,
+        RelayConfig, SpawnPointConfig, SpecialFunctionConfig, StreamedAudioConfig, SwitchConfig,
+        TimerConfig, TriggerConfig, WaterConfig, WaypointConfig, WorldLightFaderConfig,
     },
     patcher::PatcherState,
     patches::{string_to_cstr, WaterType},
@@ -144,7 +143,9 @@ macro_rules! add_edit_obj_helper {
 
 macro_rules! resolve_name {
     ($name:expr, $type:ident) => {
-        string_to_cstr($name.unwrap_or_else(|| concat!("randomprime ", stringify!($type)).to_string()))
+        string_to_cstr(
+            $name.unwrap_or_else(|| concat!("randomprime ", stringify!($type)).to_string()),
+        )
     };
 }
 

--- a/src/dol_patches.rs
+++ b/src/dol_patches.rs
@@ -2830,8 +2830,17 @@ fn patch_game_options(
         dol_patcher.ppcasm_patch(&patch)?;
     }
 
+    // Patch to always allow cutscene skipping regardless of "seen" cutscenes
+    // return false if there is no active cinematic (teardown race condition)
     dol_patcher.ppcasm_patch(&ppcasm!(symbol_addr!("ShouldSkipCinematic__22CScriptSpecialFunctionFR13CStateManager", version), {
-        li r3, 0x1; blr;
+        lwz  r3, 0x870(r4);  // r3 = mgr.CameraManager()
+        lwz  r0, 0x8(r3);    // r0 = cineCameras.count
+        cmpwi r0, 0x0;
+        li   r3, 0x0;
+        beq  no_active_cinematic;
+        li   r3, 0x1;
+    no_active_cinematic:
+        blr;
     }))?;
 
     Ok(())

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -2632,7 +2632,8 @@ fn patch_add_item<'r>(
         pickup_model_data.animation_parameters.file_id =
             ResId::<res_id::ANCS>::new(extern_model.as_ref().unwrap().ancs);
         pickup_model_data.part = ResId::invalid();
-        pickup_model_data.animation_parameters.node_index = extern_model.as_ref().unwrap().character;
+        pickup_model_data.animation_parameters.node_index =
+            extern_model.as_ref().unwrap().character;
         pickup_model_data.animation_parameters.default_animation = 0;
         pickup_model_data.actor_parameters.xray_model = ResId::invalid();
         pickup_model_data.actor_parameters.xray_skin = ResId::invalid();
@@ -4444,7 +4445,8 @@ fn modify_pickups_in_mrea<'r>(
         pickup_model_data.animation_parameters.file_id =
             ResId::<res_id::ANCS>::new(extern_model.as_ref().unwrap().ancs);
         pickup_model_data.part = ResId::invalid();
-        pickup_model_data.animation_parameters.node_index = extern_model.as_ref().unwrap().character;
+        pickup_model_data.animation_parameters.node_index =
+            extern_model.as_ref().unwrap().character;
         pickup_model_data.animation_parameters.default_animation = 0;
         pickup_model_data.actor_parameters.xray_model = ResId::invalid();
         pickup_model_data.actor_parameters.xray_skin = ResId::invalid();
@@ -7738,7 +7740,8 @@ fn make_main_plaza_locked_door_two_ways(
         .find(|obj| obj.instance_id == door_id)
         .and_then(|obj| obj.property_data.as_door_mut())
         .unwrap();
-    locked_door.animation_parameters.file_id = resource_info!("newmetroiddoor.ANCS").try_into().unwrap();
+    locked_door.animation_parameters.file_id =
+        resource_info!("newmetroiddoor.ANCS").try_into().unwrap();
     locked_door.animation_parameters.default_animation = 2;
     locked_door.projectiles_collide = 0;
 
@@ -12324,8 +12327,9 @@ fn patch_add_dock_teleport<'r>(
 
         door_rotation = door.rotation;
         is_frigate_door = door.animation_parameters.file_id == 0xfafb5784;
-        is_ceiling_door =
-            door.animation_parameters.file_id == 0xf57dd484 && door_rotation[0] > -90.0 && door_rotation[0] < 90.0;
+        is_ceiling_door = door.animation_parameters.file_id == 0xf57dd484
+            && door_rotation[0] > -90.0
+            && door_rotation[0] < 90.0;
         is_floor_door = door.animation_parameters.file_id == 0xf57dd484
             && door_rotation[0] < -90.0
             && door_rotation[0] > -270.0;

--- a/structs/src/scly_props/grapple_point.rs
+++ b/structs/src/scly_props/grapple_point.rs
@@ -1,7 +1,7 @@
 use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
-use crate::{SclyPropertyData, scly_props::structs::GrappleParameters};
+use crate::{scly_props::structs::GrappleParameters, SclyPropertyData};
 
 #[auto_struct(Readable, Writable)]
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
# Changes

- Fixes the crash that occurs when a cutscene is skipped on the same frame as being deconstructed

# Validation

1. Reproduce the crash on 0-00 and PAL on `main` to identify which frame to skip to crashes the game
2. Switch to this branch, patch
3. See that it does not crash when skipped at either the crash frame or any of the 5 frames before/after