### PR TITLE
STRG localization fixes

### DIFF
--- a/schema/randomprime.schema.json
+++ b/schema/randomprime.schema.json
@@ -5781,6 +5781,7 @@
         "allRooms": {
             "type": "string",
             "enum": [
+                "Credits",
                 "Chozo Ruins:Antechamber",
                 "Chozo Ruins:Arboretum Access",
                 "Chozo Ruins:Arboretum",

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -10304,12 +10304,21 @@ fn patch_memorycard_strg(res: &mut structs::Resource, version: Version) -> Resul
     Ok(())
 }
 
+// Languages each version's front-end can be set to. The rest are filled in with empty strings so
+// every table stays the same length.
+fn front_end_languages(version: Version) -> Languages {
+    match version {
+        Version::NtscJ => Languages::Some(&[b"ENGL", b"JAPN"]),
+        Version::Pal => Languages::Some(&[b"ENGL", b"FREN", b"GERM", b"SPAN", b"ITAL"]),
+        _ => Languages::Some(&[b"ENGL"]),
+    }
+}
+
 fn patch_main_strg(res: &mut structs::Resource, version: Version, msg: &str) -> Result<(), String> {
+    let strg = res.kind.as_strg_mut().unwrap();
+
     if version == Version::NtscJ {
-        let strings_jpn = res
-            .kind
-            .as_strg_mut()
-            .unwrap()
+        let strings_jpn = strg
             .string_tables
             .as_mut_vec()
             .iter_mut()
@@ -10320,30 +10329,9 @@ fn patch_main_strg(res: &mut structs::Resource, version: Version, msg: &str) -> 
 
         let s = strings_jpn.get_mut(37).unwrap();
         *s = "&main-color=#FFFFFF;エクストラ\u{0}".to_string().into();
-        strings_jpn.push(format!("{}\0", msg).into());
     }
 
-    if version == Version::Pal {
-        for lang in [b"FREN", b"GERM", b"SPAN", b"ITAL"] {
-            let strings_pal = res
-                .kind
-                .as_strg_mut()
-                .unwrap()
-                .string_tables
-                .as_mut_vec()
-                .iter_mut()
-                .find(|table| table.lang == lang.into())
-                .unwrap()
-                .strings
-                .as_mut_vec();
-            strings_pal.push(format!("{}\0", msg).into());
-        }
-    }
-
-    let strings = res
-        .kind
-        .as_strg_mut()
-        .unwrap()
+    let strings = strg
         .string_tables
         .as_mut_vec()
         .iter_mut()
@@ -10357,7 +10345,8 @@ fn patch_main_strg(res: &mut structs::Resource, version: Version, msg: &str) -> 
         .find(|s| *s == "Metroid Fusion Connection Bonuses\u{0}")
         .unwrap();
     *s = "Extras\u{0}".to_string().into();
-    strings.push(format!("{}\0", msg).into());
+
+    strg.add_strings(&[format!("{}\0", msg)], front_end_languages(version));
 
     Ok(())
 }
@@ -10517,7 +10506,7 @@ fn patch_credits(
         res.kind
             .as_strg_mut()
             .unwrap()
-            .add_strings(&[output.to_string()], Languages::Some(&[b"ENGL", b"JAPN"]));
+            .add_strings_jpn_font(&[output.to_string()], front_end_languages(version));
     } else {
         res.kind
             .as_strg_mut()

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -10265,41 +10265,42 @@ fn patch_save_station_for_warp_to_start<'r>(
     Ok(())
 }
 
-fn patch_memorycard_strg(res: &mut structs::Resource, version: Version) -> Result<(), String> {
-    if version == Version::NtscJ {
-        let strings = res
-            .kind
-            .as_strg_mut()
-            .unwrap()
-            .string_tables
-            .as_mut_vec()
-            .iter_mut()
-            .find(|table| table.lang == b"JAPN".into())
-            .unwrap()
-            .strings
-            .as_mut_vec();
+// Both of these are the same index in every version, but the text they hold is localized, so the
+// only way to reach every language is by index. check_english_string guards the assumption.
+const SAVE_PROMPT_INDEX: usize = 8;
+const EXTRAS_MENU_INDEX: usize = 37;
 
-        let s = strings.get_mut(8).unwrap();
-        *s = "スロットAのメモリーカードに\nデータをセーブしますか？\n&image=SI,0.70,0.68,46434ED3; + &image=SI,0.70,0.68,08A2E4B9; キーを押したまま、「いいえ」を選択して開始ルームにワープします。\u{0}".to_string().into();
-    } else {
-        let strings = res
-            .kind
-            .as_strg_mut()
-            .unwrap()
-            .string_tables
-            .as_mut_vec()
-            .iter_mut()
-            .find(|table| table.lang == b"ENGL".into())
-            .unwrap()
-            .strings
-            .as_mut_vec();
-
-        let s = strings
-            .iter_mut()
-            .find(|s| *s == "Save progress to Memory Card in Slot A?\u{0}")
-            .unwrap();
-        *s = "Save progress to Memory Card in Slot A?\nHold &image=SI,0.70,0.68,46434ED3; + &image=SI,0.70,0.68,08A2E4B9; while choosing No to warp to starting room.\u{0}".to_string().into();
+fn check_english_string(strg: &structs::Strg, index: usize, expected: &str) -> Result<(), String> {
+    match strg.string_at(index, b"ENGL") {
+        Some(string) if string.starts_with(expected) => Ok(()),
+        found => Err(format!(
+            "Expected STRG index {} to start with {:?}, found {:?}",
+            index, expected, found
+        )),
     }
+}
+
+fn patch_memorycard_strg(res: &mut structs::Resource) -> Result<(), String> {
+    const WARP_HINT: &str = "\nHold &image=SI,0.70,0.68,46434ED3; + &image=SI,0.70,0.68,08A2E4B9; while choosing No to warp to starting room.";
+    const WARP_HINT_JPN: &str = "\n&image=SI,0.70,0.68,46434ED3; + &image=SI,0.70,0.68,08A2E4B9; キーを押したまま、「いいえ」を選択して開始ルームにワープします。";
+
+    let strg = res.kind.as_strg_mut().unwrap();
+    check_english_string(
+        strg,
+        SAVE_PROMPT_INDEX,
+        "Save progress to Memory Card in Slot A?",
+    )?;
+
+    strg.append_to_string(
+        SAVE_PROMPT_INDEX,
+        WARP_HINT,
+        Languages::Some(structs::NON_JPN_LANGUAGES),
+    );
+    strg.append_to_string(
+        SAVE_PROMPT_INDEX,
+        WARP_HINT_JPN,
+        Languages::Some(&[b"JAPN"]),
+    );
 
     Ok(())
 }
@@ -10316,35 +10317,20 @@ fn front_end_languages(version: Version) -> Languages {
 
 fn patch_main_strg(res: &mut structs::Resource, version: Version, msg: &str) -> Result<(), String> {
     let strg = res.kind.as_strg_mut().unwrap();
+    check_english_string(strg, EXTRAS_MENU_INDEX, "Metroid Fusion Connection Bonuses")?;
 
-    if version == Version::NtscJ {
-        let strings_jpn = strg
-            .string_tables
-            .as_mut_vec()
-            .iter_mut()
-            .find(|table| table.lang == b"JAPN".into())
-            .unwrap()
-            .strings
-            .as_mut_vec();
-
-        let s = strings_jpn.get_mut(37).unwrap();
-        *s = "&main-color=#FFFFFF;エクストラ\u{0}".to_string().into();
-    }
-
-    let strings = strg
-        .string_tables
-        .as_mut_vec()
-        .iter_mut()
-        .find(|table| table.lang == b"ENGL".into())
-        .unwrap()
-        .strings
-        .as_mut_vec();
-
-    let s = strings
-        .iter_mut()
-        .find(|s| *s == "Metroid Fusion Connection Bonuses\u{0}")
-        .unwrap();
-    *s = "Extras\u{0}".to_string().into();
+    // Randomprime repurposes the GBA bonus menu, so its entry has to be renamed in every language
+    // the player can pick
+    strg.set_string(
+        EXTRAS_MENU_INDEX,
+        "Extras\u{0}",
+        Languages::Some(structs::NON_JPN_LANGUAGES),
+    );
+    strg.set_string(
+        EXTRAS_MENU_INDEX,
+        "&main-color=#FFFFFF;エクストラ\u{0}",
+        Languages::Some(&[b"JAPN"]),
+    );
 
     strg.add_strings(&[format!("{}\0", msg)], front_end_languages(version));
 
@@ -18090,7 +18076,7 @@ fn build_and_run_patches<'r>(
 
         patcher.add_resource_patch(
             resource_info!("STRG_MemoryCard.STRG").into(), // 0x19C3F7F7
-            |res| patch_memorycard_strg(res, config.version),
+            patch_memorycard_strg,
         );
     }
 

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -10488,17 +10488,10 @@ fn patch_credits(
         }
     }
     output = format!("{}{}", output, "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\0");
-    if version == Version::NtscJ {
-        res.kind
-            .as_strg_mut()
-            .unwrap()
-            .add_strings_jpn_font(&[output.to_string()], front_end_languages(version));
-    } else {
-        res.kind
-            .as_strg_mut()
-            .unwrap()
-            .add_strings(&[output.to_string()], Languages::All);
-    }
+    res.kind
+        .as_strg_mut()
+        .unwrap()
+        .add_strings(&[output.to_string()], Languages::All);
 
     /* We are who we choose to be */
     /* https://mobile.twitter.com/ZoidCTF/status/1542699504041750528 */

--- a/structs/src/strg.rs
+++ b/structs/src/strg.rs
@@ -75,16 +75,6 @@ impl<'r> Strg<'r> {
     }
 
     pub fn add_strings(&mut self, strings: &[String], languages: Languages) {
-        self.append_strings(strings, languages, "");
-    }
-
-    // The JP build renders with the Japanese font unless a string names another, so text meant to
-    // read as Latin has to say so itself.
-    pub fn add_strings_jpn_font(&mut self, strings: &[String], languages: Languages) {
-        self.append_strings(strings, languages, JPN_FONT_PREFIX);
-    }
-
-    fn append_strings(&mut self, strings: &[String], languages: Languages, prefix: &str) {
         let languages = match languages {
             Languages::All => SUPPORTED_LANGUAGES,
             Languages::Some(value) => value,
@@ -94,7 +84,7 @@ impl<'r> Strg<'r> {
             let selected = languages.contains(&table.lang.as_bytes());
             for string in strings.iter() {
                 let string = match selected {
-                    true => format!("{}{}", prefix, string),
+                    true => string.to_string(),
                     false => EMPTY_STRING.to_string(),
                 };
                 table.strings.as_mut_vec().push(string.into());

--- a/structs/src/strg.rs
+++ b/structs/src/strg.rs
@@ -7,6 +7,8 @@ static SUPPORTED_LANGUAGES: &[&[u8; 4]] = &[
     b"ENGL", b"DUTC", b"FREN", b"GERM", b"ITAL", b"JAPN", b"SPAN",
 ];
 
+pub static NON_JPN_LANGUAGES: &[&[u8; 4]] = &[b"ENGL", b"DUTC", b"FREN", b"GERM", b"ITAL", b"SPAN"];
+
 const EMPTY_STRING: &str = "\u{0}";
 const JPN_FONT_PREFIX: &str = "&line-extra-space=4;&font=C29C51F1;";
 
@@ -113,6 +115,52 @@ impl<'r> Strg<'r> {
                     }
                 }
             }
+        }
+    }
+
+    pub fn string_at(&self, index: usize, language: &[u8; 4]) -> Option<String> {
+        self.string_tables
+            .iter()
+            .find(|table| table.lang == language.into())?
+            .strings
+            .iter()
+            .nth(index)
+            .map(|string| string.into_owned().into_string())
+    }
+
+    pub fn set_string(&mut self, index: usize, string: &str, languages: Languages) {
+        self.edit_string_at(index, languages, |_| string.to_string());
+    }
+
+    // Keeps each language's own text and adds to it, for suffixes that read the same everywhere.
+    pub fn append_to_string(&mut self, index: usize, suffix: &str, languages: Languages) {
+        self.edit_string_at(index, languages, |string| {
+            format!(
+                "{}{}{}",
+                string.trim_end_matches('\u{0}'),
+                suffix,
+                EMPTY_STRING
+            )
+        });
+    }
+
+    fn edit_string_at(
+        &mut self,
+        index: usize,
+        languages: Languages,
+        edit: impl Fn(String) -> String,
+    ) {
+        let languages = match languages {
+            Languages::All => SUPPORTED_LANGUAGES,
+            Languages::Some(value) => value,
+        };
+
+        for table in self.string_tables.as_mut_vec().iter_mut() {
+            if !languages.contains(&table.lang.as_bytes()) {
+                continue;
+            }
+            let strings = table.strings.as_mut_vec();
+            strings[index] = edit(strings[index].clone().into_string()).into();
         }
     }
 

--- a/structs/src/strg.rs
+++ b/structs/src/strg.rs
@@ -7,6 +7,9 @@ static SUPPORTED_LANGUAGES: &[&[u8; 4]] = &[
     b"ENGL", b"DUTC", b"FREN", b"GERM", b"ITAL", b"JAPN", b"SPAN",
 ];
 
+const EMPTY_STRING: &str = "\u{0}";
+const JPN_FONT_PREFIX: &str = "&line-extra-space=4;&font=C29C51F1;";
+
 pub enum Languages {
     All,
     Some(&'static [&'static [u8; 4]]),
@@ -22,8 +25,17 @@ pub struct Strg<'r> {
 
     #[auto_struct(derive = string_tables.len() as u32)]
     lang_count: u32,
-    // TODO: It might be nice to have an assert that all the tables have the same length
-    #[auto_struct(derive = string_tables.iter().next().unwrap().strings.len() as u32)]
+
+    #[auto_struct(derive = {
+        let mut lengths = string_tables.iter().map(|table| table.strings.len());
+        let count = lengths.next().unwrap();
+        assert!(
+            lengths.all(|len| len == count),
+            "STRG language tables hold differing numbers of strings. Fix: Call `pad_string_tables after` \
+             appending to a subset of the languages"
+        );
+        count as u32
+    })]
     string_count: u32,
 
     #[auto_struct(derive_from_iter = string_tables.iter()
@@ -42,30 +54,48 @@ pub struct Strg<'r> {
 }
 
 impl<'r> Strg<'r> {
-    fn is_jpn_version(languages: &[&[u8; 4]]) -> bool {
-        languages.len() == 2
-            && languages.iter().any(|lang| *lang == b"ENGL")
-            && languages.iter().any(|lang| *lang == b"JAPN")
+    // Grow every language table to the length of the longest, so the file-wide string count in
+    // the header stays accurate. Only needed after pushing onto tables directly.
+    pub fn pad_string_tables(&mut self) {
+        let tables = self.string_tables.as_mut_vec();
+        let longest = tables
+            .iter()
+            .map(|table| table.strings.len())
+            .max()
+            .unwrap_or(0);
+
+        for table in tables.iter_mut() {
+            let strings = table.strings.as_mut_vec();
+            while strings.len() < longest {
+                strings.push(EMPTY_STRING.to_string().into());
+            }
+        }
     }
 
     pub fn add_strings(&mut self, strings: &[String], languages: Languages) {
+        self.append_strings(strings, languages, "");
+    }
+
+    // The JP build renders with the Japanese font unless a string names another, so text meant to
+    // read as Latin has to say so itself.
+    pub fn add_strings_jpn_font(&mut self, strings: &[String], languages: Languages) {
+        self.append_strings(strings, languages, JPN_FONT_PREFIX);
+    }
+
+    fn append_strings(&mut self, strings: &[String], languages: Languages, prefix: &str) {
         let languages = match languages {
             Languages::All => SUPPORTED_LANGUAGES,
             Languages::Some(value) => value,
         };
-        let is_jpn = Self::is_jpn_version(languages);
+
         for table in self.string_tables.as_mut_vec().iter_mut() {
-            if languages.contains(&table.lang.as_bytes()) {
-                for string in strings.iter() {
-                    if is_jpn {
-                        table
-                            .strings
-                            .as_mut_vec()
-                            .push(format!("&line-extra-space=4;&font=C29C51F1;{}", string).into());
-                    } else {
-                        table.strings.as_mut_vec().push(string.to_string().into());
-                    }
-                }
+            let selected = languages.contains(&table.lang.as_bytes());
+            for string in strings.iter() {
+                let string = match selected {
+                    true => format!("{}{}", prefix, string),
+                    false => EMPTY_STRING.to_string(),
+                };
+                table.strings.as_mut_vec().push(string.into());
             }
         }
     }
@@ -103,7 +133,7 @@ impl<'r> Strg<'r> {
     pub fn from_strings_jpn(strings: Vec<String>) -> Strg<'r> {
         let strings: LazyArray<LazyUtf16beStr> = strings
             .into_iter()
-            .map(|i| format!("&line-extra-space=4;&font=C29C51F1;{}", i).into())
+            .map(|i| format!("{}{}", JPN_FONT_PREFIX, i).into())
             .collect::<Vec<_>>()
             .into();
         Strg {


### PR DESCRIPTION
Randomprime was corrupting STRG tables when pushing new strings. STRG tables are supposed to contain the same number of entries for all localizations. Implement a system to normalize this.

Separately but related, warp-to-start prompt text was only being added to the non-JP English STRG entry. This is now fixed as well.
- Fixes #29

## Validation

This used to fail on `main` ISOs:

```py
from pathlib import Path
from retro_data_structures.asset_manager import AssetManager
from retro_data_structures.file_provider import IsoFileProvider
from retro_data_structures.formats.strg import Strg
from retro_data_structures.game_check import Game
m=AssetManager(IsoFileProvider(Path('primeOut.iso')),Game.PRIME)
for i in m.all_asset_ids_of_type('STRG'):
    try: m.get_parsed_asset(i,type_hint=Strg)
    except Exception as e: print(f'{i:08X} {type(e).__name__}')
```

<img width="2618" height="1152" alt="Screenshot_1" src="https://github.com/user-attachments/assets/9b68c439-e3e2-4a78-9319-66c7530f17e3" />

