### PR TITLE
Elite Research persistent pickup

### DIFF
--- a/generated/json_data/skippable_cutscenes_pal.jsonc
+++ b/generated/json_data/skippable_cutscenes_pal.jsonc
@@ -226,6 +226,24 @@
                         }
                     ]
                 },
+                "Elite Research": {
+                    "removeConnections": [
+                        {
+                            "senderId": 851977, // [SpecialFunction] SpecialFunction Cinematic Skip
+                            "targetId": 852800, // [Pickup] Artifact
+                            "state": "ZERO",
+                            "message": "ACTIVATE"
+                        }
+                    ],
+                    "addConnections": [
+                        {
+                            "senderId": 851977, // [SpecialFunction] SpecialFunction Cinematic Skip
+                            "targetId": 853284, // [MemoryRelay] Memory Relay Artifact Post Elite
+                            "state": "ZERO",
+                            "message": "ACTIVATE"
+                        }
+                    ]
+                },
                 "Mine Security Station": {
                     "deleteIds": [
                         458753,

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -18586,7 +18586,7 @@ fn patch_elite_research_door_lock_0_02(
         .unwrap();
 
     let connections = obj.connections.as_mut_vec();
-    connections.retain(|conn| conn.target_object_id & 0xFFFFF != 0xD0517);
+    connections.retain(|conn| conn.target_object_id & 0xFFFFF != door_unlock_relay_id);
 
     Ok(())
 }

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -13483,6 +13483,10 @@ fn patch_qol_game_breaking(
             resource_info!("04_mines_pillar.MREA").into(),
             patch_ore_processing_door_lock_0_02,
         );
+        patcher.add_scly_patch(
+            resource_info!("03_mines.MREA").into(),
+            patch_elite_research_door_lock_0_02,
+        );
     }
     if version == Version::Pal
         || version == Version::NtscJ
@@ -13518,6 +13522,16 @@ fn patch_qol_game_breaking(
         }
     }
 
+    if version == Version::NtscU0_00
+        || version == Version::NtscU0_01
+        || version == Version::NtscU0_02
+        || version == Version::NtscK
+    {
+        patcher.add_scly_patch(
+            resource_info!("03_mines.MREA").into(),
+            patch_elite_research_persistent_pickup,
+        );
+    }
     // softlocks
     patcher.add_scly_patch(
         resource_info!("22_Flaahgra.MREA").into(),
@@ -17489,10 +17503,6 @@ fn build_and_run_patches<'r>(
             player_size < 0.9,
         );
 
-        patcher.add_scly_patch(resource_info!("03_mines.MREA").into(), move |ps, area| {
-            patch_elite_research_door_lock(ps, area, game_resources)
-        });
-
         if boss_permadeath {
             patcher.add_scly_patch(
                 resource_info!("03f_crater.MREA").into(), // lair
@@ -18474,181 +18484,109 @@ fn patch_elite_research_platforms(
     Ok(())
 }
 
-fn patch_elite_research_door_lock<'r>(
+fn patch_elite_research_persistent_pickup(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
-    game_resources: &HashMap<(u32, FourCC), structs::Resource<'r>>,
+    area: &mut mlvl_wrapper::MlvlArea,
 ) -> Result<(), String> {
-    let deps = [
-        (0x6E5D6796, b"CMDL"),
-        (0x0D36FB59, b"TXTR"),
-        (0xACADD83F, b"TXTR"),
-    ];
-    let deps_iter = deps.iter().map(|&(file_id, fourcc)| Dependency {
-        asset_id: file_id,
-        asset_type: FourCC::from_bytes(fourcc),
-    });
-    area.add_dependencies(game_resources, 0, deps_iter);
+    // Add new layer for an auto-start Timer that will activate the pickup
+    area.add_layer(b"Pickup Active\0".as_cstr());
+    let pickup_active_layer = area.get_layer_id_from_name("Pickup Active");
 
-    // Must assign new object id here to keep borrow checker happy
-    let top_door_lock_id: u32 = area.new_object_id_from_layer_id(1);
-    let scly = area.mrea().scly_section_mut();
+    // Layer starts Inactive by Default
+    let flags = &mut area.layer_flags.flags;
+    *flags &= !(1 << 6);
 
-    let elite_pirate_id: u32 = 0x000D01A4;
-    let relay_disable_lock_id: u32 = 0x000D0407;
-    let artifact_id: u32 = 0x000D0340;
-    let bottom_door_lock_id: u32 = 0x000D0405;
-    let special_function_id: u32 = 0x000D04D1;
+    let special_fn_id = area.new_object_id_from_layer_id(0);
+    let pickup_timer_id = area.new_object_id_from_layer_name("Pickup Active");
+    let pickup_id = 0xD0340;
 
-    // Create lock for top door
-    let top_door_lock = structs::SclyObject {
-        instance_id: top_door_lock_id,
-        connections: vec![].into(),
-        property_data: SclyProperty::Actor(Box::new(structs::Actor {
-            name: b"Custom Blast Shield\0".as_cstr(),
-            position: [21.35, 166.275_13, 51.825].into(),
-            rotation: [0.0, 0.0, 0.0].into(),
-            scale: [1.45, 1.45, 1.45].into(),
-            collision_box: [1.75, 5.0, 5.0].into(),
-            collision_offset: [0.0, 0.0, 0.0].into(),
-            mass: 1.0,
-            gravity: 0.0,
-            health_info: structs::scly_structs::HealthInfo {
-                health: 5.0,
-                knockback_resistance: 1.0,
-            },
-            damage_vulnerability: structs::scly_structs::DamageVulnerability {
-                power: structs::scly_structs::TypeVulnerability::Reflect as u32,
-                ice: structs::scly_structs::TypeVulnerability::Reflect as u32,
-                wave: structs::scly_structs::TypeVulnerability::Reflect as u32,
-                plasma: structs::scly_structs::TypeVulnerability::Reflect as u32,
-                bomb: structs::scly_structs::TypeVulnerability::Immune as u32,
-                power_bomb: structs::scly_structs::TypeVulnerability::Reflect as u32,
-                missile: structs::scly_structs::TypeVulnerability::Reflect as u32,
-                boost_ball: structs::scly_structs::TypeVulnerability::Immune as u32,
-                phazon: structs::scly_structs::TypeVulnerability::Immune as u32,
-
-                enemy_weapon0: structs::scly_structs::TypeVulnerability::Immune as u32,
-                enemy_weapon1: structs::scly_structs::TypeVulnerability::Immune as u32,
-                enemy_weapon2: structs::scly_structs::TypeVulnerability::Immune as u32,
-                enemy_weapon3: structs::scly_structs::TypeVulnerability::Immune as u32,
-
-                unknown_weapon0: structs::scly_structs::TypeVulnerability::Immune as u32,
-                unknown_weapon1: structs::scly_structs::TypeVulnerability::Immune as u32,
-                unknown_weapon2: structs::scly_structs::TypeVulnerability::Immune as u32,
-
-                charged_beams: structs::scly_structs::ChargedBeams {
-                    power: structs::scly_structs::TypeVulnerability::Reflect as u32,
-                    ice: structs::scly_structs::TypeVulnerability::Reflect as u32,
-                    wave: structs::scly_structs::TypeVulnerability::Reflect as u32,
-                    plasma: structs::scly_structs::TypeVulnerability::Reflect as u32,
-                    phazon: structs::scly_structs::TypeVulnerability::Reflect as u32,
-                },
-                beam_combos: structs::scly_structs::BeamCombos {
-                    power: structs::scly_structs::TypeVulnerability::Reflect as u32,
-                    ice: structs::scly_structs::TypeVulnerability::Reflect as u32,
-                    wave: structs::scly_structs::TypeVulnerability::Reflect as u32,
-                    plasma: structs::scly_structs::TypeVulnerability::Reflect as u32,
-                    phazon: structs::scly_structs::TypeVulnerability::Reflect as u32,
-                },
-            },
-            static_model: ResId::new(0x6E5D6796),
-            animation_parameters: structs::scly_structs::AncsProp {
-                file_id: ResId::invalid(),
-                node_index: 0,
-                default_animation: 0xFFFFFFFF,
-            },
-            actor_parameters: structs::scly_structs::ActorParameters {
-                light_parameters: structs::scly_structs::LightParameters {
-                    cast_shadow: 1,
-                    shadow_scale: 1.0,
-                    tessellation: 0,
-                    shadow_alpha: 1.0,
-                    max_shadow_height: 20.0,
-                    ambient_color: [1.0, 1.0, 1.0, 1.0].into(), // RGBA
-                    make_lights: 1,
-                    use_world_lighting: 1,
-                    light_recalculation: 1,
-                    lighting_position: [0.0, 0.0, 0.0].into(),
-                    num_dynamic_lights: 4,
-                    num_area_lights: 4,
-                    ignore_ambient_lighting: 0,
-                    use_light_set: 0,
-                },
-                scan_parameters: structs::scly_structs::ScannableParameters {
-                    scan: ResId::invalid(),
-                },
-                xray_model: ResId::invalid(),
-                xray_skin: ResId::invalid(),
-                thermal_model: ResId::invalid(),
-                thermal_skin: ResId::invalid(),
-                use_global_render_time: 1,
-                fade_in_time: 1.0,
-                fade_out_time: 1.0,
-                visor_parameters: structs::scly_structs::VisorParameters {
-                    unknown0: 0,
-                    target_passthrough: 1,
-                    visor_mask: 15, // Visor Flags : Combat|Scan|Thermal|XRay
-                },
-                thermal_hot: 0,
-                force_render_unsorted: 0,
-                no_sort_thermal: 0,
-                thermal_damage_magnitude: 1.0,
-            },
-            is_loop: 1,
-            immovable: 1,
-            is_solid: 1,
-            is_camera_through: 0,
-            active: 0,
-            render_texture_set: 0,
-            xray_alpha: 1.0,
-            thermal_visible_through_geometry: 0,
-            draws_shadow: 0,
-            scale_animation: 0,
-            material_flag_54: 0,
-        })),
+    // Activate new layer when Phazon Elite dies
+    let connection = ConnectionConfig {
+        sender_id: 0xD01A4, // Phazon Elite
+        target_id: special_fn_id,
+        state: ConnectionState::DEAD,
+        message: ConnectionMsg::INCREMENT,
     };
+    patch_add_connection(area, &connection);
 
-    // Add to "3rd Pass Elite Bustout" layer
-    scly.layers.as_mut_vec()[1]
+    // Deactivate new layer when Pickup obtained
+    let connection = ConnectionConfig {
+        sender_id: pickup_id,
+        target_id: special_fn_id,
+        state: ConnectionState::ARRIVED,
+        message: ConnectionMsg::DECREMENT,
+    };
+    patch_add_connection(area, &connection);
+
+    let scly = area.mrea().scly_section_mut();
+    let layers = &mut scly.layers.as_mut_vec();
+
+    // This auto-start timer will activate the pickup on room load
+    layers[pickup_active_layer]
         .objects
         .as_mut_vec()
-        .push(top_door_lock);
-
-    // Adjust connections
-    for layer in scly.layers.as_mut_vec().iter_mut() {
-        for obj in layer.objects.as_mut_vec().iter_mut() {
-            // Remove bottom door unlock connection from Elite Pirate
-            if obj.instance_id & 0x00FFFFFF == relay_disable_lock_id & 0x00FFFFFF {
-                obj.connections.as_mut_vec().retain(|conn| {
-                    !conn.target_object_id & 0x00FFFFFF == elite_pirate_id & 0x00FFFFFF
-                });
-            };
-
-            // Add top and bottom door unlock connections to Artifact
-            if obj.instance_id & 0x00FFFFFF == artifact_id & 0x00FFFFFF {
-                obj.connections.as_mut_vec().push(structs::Connection {
-                    state: structs::ConnectionState::ARRIVED,
-                    message: structs::ConnectionMsg::DECREMENT,
-                    target_object_id: bottom_door_lock_id,
-                });
-                obj.connections.as_mut_vec().push(structs::Connection {
-                    state: structs::ConnectionState::ARRIVED,
-                    message: structs::ConnectionMsg::DECREMENT,
-                    target_object_id: top_door_lock_id,
-                });
-            };
-
-            // Add top door lock connection to "SpecialFunction PlayerInAreaRelay"
-            if obj.instance_id & 0x00FFFFFF == special_function_id & 0x00FFFFFF {
-                obj.connections.as_mut_vec().push(structs::Connection {
-                    state: structs::ConnectionState::ZERO,
-                    message: structs::ConnectionMsg::INCREMENT,
-                    target_object_id: top_door_lock_id,
-                });
+        .push(structs::SclyObject {
+            instance_id: pickup_timer_id,
+            property_data: structs::Timer {
+                name: b"Activate Pickup\0".as_cstr(),
+                start_time: 0.001,
+                max_random_add: 0.0,
+                looping: 0,
+                start_immediately: 1,
+                active: 1,
             }
-        }
-    }
+            .into(),
+            connections: vec![structs::Connection {
+                state: structs::ConnectionState::ZERO,
+                message: structs::ConnectionMsg::ACTIVATE,
+                target_object_id: pickup_id,
+            }]
+            .into(),
+        });
+
+    // Layer Controller
+    layers[0].objects.as_mut_vec().push(structs::SclyObject {
+        instance_id: special_fn_id,
+        property_data: structs::SpecialFunction::layer_change_fn(
+            b"[INC/DEC] Pickup Active\0".as_cstr(),
+            0xD3438CDA,
+            pickup_active_layer as u32,
+        )
+        .into(),
+        connections: vec![].into(),
+    });
+
+    Ok(())
+}
+
+fn patch_elite_research_door_lock_0_02(
+    _ps: &mut PatcherState,
+    area: &mut mlvl_wrapper::MlvlArea,
+) -> Result<(), String> {
+    let phazon_elite_id = 0xD01A4;
+    let door_unlock_relay_id = 0xD0517;
+
+    // Unlock door and move platforms when Phazon Elite dies
+    let connection = ConnectionConfig {
+        sender_id: phazon_elite_id,
+        target_id: door_unlock_relay_id,
+        state: ConnectionState::DEAD,
+        message: ConnectionMsg::SET_TO_ZERO,
+    };
+    patch_add_connection(area, &connection);
+
+    let scly = area.mrea().scly_section_mut();
+    let layers = scly.layers.as_mut_vec();
+
+    // Don't fire that same relay again on collecting pickup
+    let obj = layers[0]
+        .objects
+        .iter_mut()
+        .find(|obj| obj.instance_id & 0xFFFFF == 0xD0340)
+        .unwrap();
+
+    let connections = obj.connections.as_mut_vec();
+    connections.retain(|conn| conn.target_object_id & 0xFFFFF != 0xD0517);
 
     Ok(())
 }


### PR DESCRIPTION
# Changes
- Implemented PAL method of fixing this pickup being permanently gone if left room after it spawns (From 0-00 to NTSC-K)
  - Changed door unlocking behavior back to how it is in previous versions
- Removed previous patch which was leaving the bottom door locked (and adding a new one for the top door)

# Validation
https://youtu.be/nRyq_wgpePg

# Other Changes
- PAL: Fixed Pickup Reveal cutscene skip not activating the persistent pickup Memory Relay