### PR TITLE
Fix Blast Shield visual persistence on 2nd pass

### DIFF
--- a/src/patches.rs
+++ b/src/patches.rs
@@ -796,9 +796,9 @@ fn patch_door<'r>(
         sound_id = area.new_object_id_from_layer_id(0);
         streamed_audio_id = area.new_object_id_from_layer_id(0);
         shaker_id = area.new_object_id_from_layer_id(0);
-        blast_shield_instance_id = area.new_object_id_from_layer_id(0);
         effect_id = area.new_object_id_from_layer_id(0);
 
+        blast_shield_instance_id = area.new_object_id_from_layer_id(blast_shield_layer_idx);
         timer_id = area.new_object_id_from_layer_id(blast_shield_layer_idx);
         timer2_id = area.new_object_id_from_layer_id(blast_shield_layer_idx);
         relay_id = area.new_object_id_from_layer_id(blast_shield_layer_idx);


### PR DESCRIPTION
- Fixes #176

In an early iteration of PR #155, invariant objects (e.g. rumble effect, camera shaker, etc.) were deduplicated to save memory. For that de-duplication to be effective, those assets needed to be moved to layer 0. Due to a typo, the blast shield actor was also moved to layer 0. Oops.
