### PR TITLE
Gunship Color Config Option

### DIFF
--- a/schema/randomprime.schema.json
+++ b/schema/randomprime.schema.json
@@ -161,7 +161,6 @@
                     "type": "object",
                     "properties": {
                         "powerDeg": {
-                            "description": "Hue rotation for the Power Suit. Also applied to Samus' gunship.",
                             "type": "integer",
                             "minimum": 0,
                             "exclusiveMaximum": 360,
@@ -184,6 +183,12 @@
                             "minimum": 0,
                             "exclusiveMaximum": 360,
                             "default": 0
+                        },
+                        "gunshipDeg": {
+                            "description": "Affects the appearance of Samus' Gunship in Landing Site and game into/outro cutscenes. Defaults to `powerDeg` if not provided.",
+                            "type": "integer",
+                            "minimum": 0,
+                            "exclusiveMaximum": 360
                         }
                     },
                     "required": [],

--- a/schema/randomprime.schema.json
+++ b/schema/randomprime.schema.json
@@ -161,6 +161,7 @@
                     "type": "object",
                     "properties": {
                         "powerDeg": {
+                            "description": "Hue rotation for the Power Suit. Also applied to Samus' gunship.",
                             "type": "integer",
                             "minimum": 0,
                             "exclusiveMaximum": 360,

--- a/src/patch_config.rs
+++ b/src/patch_config.rs
@@ -159,6 +159,7 @@ pub struct SuitColors {
     pub varia_deg: Option<i16>,
     pub gravity_deg: Option<i16>,
     pub phazon_deg: Option<i16>,
+    pub gunship_deg: Option<i16>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -17827,6 +17827,13 @@ fn build_and_run_patches<'r>(
     }
 
     if let Some(suit_colors) = config.suit_colors.as_ref() {
+        // If unspecified, default gunship color to power suit color
+        let gunship_deg = if let Some(gunship_deg) = suit_colors.gunship_deg {
+            Some(gunship_deg)
+        } else {
+            suit_colors.power_deg
+        };
+
         let mut suit_lists: Vec<(Vec<ResourceInfo>, Option<i16>)> = [
             (POWER_SUIT_TEXTURES, suit_colors.power_deg),
             (FUSION_POWER_SUIT_TEXTURES, suit_colors.power_deg),
@@ -17836,7 +17843,7 @@ fn build_and_run_patches<'r>(
             (FUSION_GRAVITY_SUIT_TEXTURES, suit_colors.gravity_deg),
             (PHAZON_SUIT_TEXTURES, suit_colors.phazon_deg),
             (FUSION_PHAZON_SUIT_TEXTURES, suit_colors.phazon_deg),
-            (SHIP_TEXTURES, suit_colors.power_deg),
+            (SHIP_TEXTURES, gunship_deg),
         ]
         .into_iter()
         .map(|(textures, angle)| (textures.to_vec(), angle))

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -17793,10 +17793,6 @@ fn build_and_run_patches<'r>(
     }
 
     if let Some(suit_colors) = config.suit_colors.as_ref() {
-        let ship_angle = [suit_colors.power_deg, suit_colors.varia_deg]
-            .into_iter()
-            .flatten()
-            .find(|deg| deg % 360 != 0);
         let mut suit_lists: Vec<(Vec<ResourceInfo>, Option<i16>)> = [
             (POWER_SUIT_TEXTURES, suit_colors.power_deg),
             (FUSION_POWER_SUIT_TEXTURES, suit_colors.power_deg),
@@ -17806,7 +17802,7 @@ fn build_and_run_patches<'r>(
             (FUSION_GRAVITY_SUIT_TEXTURES, suit_colors.gravity_deg),
             (PHAZON_SUIT_TEXTURES, suit_colors.phazon_deg),
             (FUSION_PHAZON_SUIT_TEXTURES, suit_colors.phazon_deg),
-            (SHIP_TEXTURES, ship_angle),
+            (SHIP_TEXTURES, suit_colors.power_deg),
         ]
         .into_iter()
         .map(|(textures, angle)| (textures.to_vec(), angle))


### PR DESCRIPTION
# Before

Gunship color would follow Power Suit color, unless Power Suit color was 0, then it would follow Varia Suit.

# After

Gunship color is defined by `gunshipDeg`, unless unspecified, then it follows Power Suit.
