### PR TITLE
Fix tentacles retracting while Flaahgra is not fainted

### DIFF
--- a/generated/json_data/skippable_cutscenes.jsonc
+++ b/generated/json_data/skippable_cutscenes.jsonc
@@ -7398,6 +7398,31 @@
                         }
                     ],
                     "addConnections": [
+                        // Cancel tentacle retract timers on extract
+                        {
+                            "senderId": 2424967, // [Relay] Extract Tentacles
+                            "state": "ZERO",
+                            "targetId": 2424908, // [Timer] Flaahgra Tentacle Retract 1
+                            "message": "STOP_AND_RESET"
+                        },
+                        {
+                            "senderId": 2424967, // [Relay] Extract Tentacles
+                            "state": "ZERO",
+                            "targetId": 2424928, // [Timer] Flaahgra Tentacle Retract 2
+                            "message": "STOP_AND_RESET"
+                        },
+                        {
+                            "senderId": 2424967, // [Relay] Extract Tentacles
+                            "state": "ZERO",
+                            "targetId": 2424913, // [Timer] Flaahgra Tentacle Retract 3
+                            "message": "STOP_AND_RESET"
+                        },
+                        {
+                            "senderId": 2424967, // [Relay] Extract Tentacles
+                            "state": "ZERO",
+                            "targetId": 2424915, // [Timer] Flaahgra Tentacle Retract 4
+                            "message": "STOP_AND_RESET"
+                        },
                         // Initial Slot Reveal Cutscene Elements
                         {
                             "senderId": 2425042, // [Counter] Counter


### PR DESCRIPTION
# Issue
If one of Flaahgra's bomb slots are destroyed shortly after it begins fainting and the resulting cutscene is skipped early, then Flaahgra will wake up with retracted tentacles.

# Solution
When cutscenes are made skippable, patch sunchamber such that the 6.2 second "tentacle retract" timers are cancelled whenever the tentacles intend to extend.

# Validation
[steps to repro in thread](https://discord.com/channels/914291389293027329/1527119249351643166)

This patch helps reproduce more easily:

```json
"controllerActions": [
    {
        "id": 10000000,
        "action": "NoVisor",
        "oneShot": true
    }
],
"spawnPoints": [
    {
        "id": 10000001,
        "position": [284.1184, 124.3721, 67.6267],
        "morphed": true                            
    }
],
"addConnections": [
    {
        "senderId": 10000000,
        "state": "OPEN",
        "targetId": 10000001,
        "message": "SET_TO_ZERO"
    }
]
```