### PR TITLE
Generic Edit - Scan Params

### DIFF
--- a/reader_writer/src/read_only_array.rs
+++ b/reader_writer/src/read_only_array.rs
@@ -18,6 +18,16 @@ where
     data_start: Reader<'r>,
 }
 
+impl<'r, T> PartialEq for RoArray<'r, T>
+where
+    T: Readable<'r> + PartialEq,
+    T::Args: Clone,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.len() == other.len() && self.iter().eq(other.iter())
+    }
+}
+
 impl<'r, T> RoArray<'r, T>
 where
     T: Readable<'r>,

--- a/schema/randomprime.schema.json
+++ b/schema/randomprime.schema.json
@@ -3719,6 +3719,47 @@
                                             "exclusiveMinimum": 0.0
                                         }
                                     }
+                                },
+                                "scannableParameters": {
+                                    "description": "Set the scan/logbook text for this object. If this object has more than one `ScannableParameters` (e.g. Flaahgra), all of them are replaced.",
+                                    "type": "object",
+                                    "properties": {
+                                        "logbookCategory": {
+                                            "description": "Which logbook category to file this entry under. If `None`, no logbook entry is created and `title` is unused.",
+                                            "enum": [
+                                                "None",
+                                                "PirateData",
+                                                "ChozoLore",
+                                                "Creatures",
+                                                "Research",
+                                                "Artifacts"
+                                            ],
+                                            "default": "None"
+                                        },
+                                        "title": {
+                                            "description": "The title used in the logbook.",
+                                            "type": "string"
+                                        },
+                                        "intro": {
+                                            "description": "The first page of the scan / first paragraph of the logbook entry.",
+                                            "type": "string"
+                                        },
+                                        "body": {
+                                            "description": "The main content of the scan/logbook entry.",
+                                            "type": "string"
+                                        },
+                                        "critical": {
+                                            "description": "If true, this scan point is styled differently (e.g. red instead of yellow).",
+                                            "type": "boolean",
+                                            "default": false
+                                        },
+                                        "slowScan": {
+                                            "description": "If true, this scan takes the longer of the game's two scan durations, as the vanilla Flaahgra, Thardus and Parasite Queen scans do.",
+                                            "type": "boolean",
+                                            "default": false
+                                        }
+                                    },
+                                    "additionalProperties": false
                                 }
                             },
                             "additionalProperties": false

--- a/schema/randomprime.schema.json
+++ b/schema/randomprime.schema.json
@@ -3738,7 +3738,8 @@
                                         },
                                         "title": {
                                             "description": "The title used in the logbook.",
-                                            "type": "string"
+                                            "type": "string",
+                                            "default": ""
                                         },
                                         "intro": {
                                             "description": "The first page of the scan / first paragraph of the logbook entry.",
@@ -3759,6 +3760,10 @@
                                             "default": false
                                         }
                                     },
+                                    "required": [
+                                        "intro",
+                                        "body"
+                                    ],
                                     "additionalProperties": false
                                 }
                             },

--- a/src/custom_assets.rs
+++ b/src/custom_assets.rs
@@ -74,21 +74,17 @@ impl ScanStrgAllocator<'_, '_> {
 }
 
 fn scan_strg_spec(config: &ScannableParametersConfig) -> ScanStrgSpec {
-    let mut strings = vec![config.intro.clone().unwrap_or_default() + "\0"];
-
-    if config.title.is_some() || config.body.is_some() {
-        strings.push(config.title.clone().unwrap_or_default() + "\0");
-    }
-
-    if let Some(body) = config.body.as_ref() {
-        strings.push(body.clone() + "\0");
-    }
+    let strings = vec![
+        config.intro.clone() + "\0",
+        config.title.clone() + "\0",
+        config.body.clone() + "\0",
+    ];
 
     ScanStrgSpec {
         strings,
-        is_important: config.critical.unwrap_or(false) as u8,
-        logbook_category: config.logbook_category.unwrap_or_default() as u32,
-        scan_speed: config.slow_scan.unwrap_or(false) as u32,
+        is_important: config.critical as u8,
+        logbook_category: config.logbook_category as u32,
+        scan_speed: config.slow_scan as u32,
     }
 }
 

--- a/src/custom_assets.rs
+++ b/src/custom_assets.rs
@@ -11,11 +11,86 @@ use crate::{
     door_meta::{BlastShieldType, DoorType},
     elevators::{SpawnRoomData, World},
     extern_assets::ExternPickupModel,
-    patch_config::{GenericTexture, PatchConfig, Version},
+    patch_config::{GenericTexture, PatchConfig, ScannableParametersConfig, Version},
     patches::WaterType,
     pickup_meta::{self, PickupModel, PickupType},
     GcDiscLookupExtensions, ResourceData,
 };
+
+#[derive(Debug, Clone, Default, Hash, PartialEq, Eq)]
+struct ScanStrgSpec {
+    strings: Vec<String>,
+    is_important: u8,
+    logbook_category: u32,
+    scan_speed: u32,
+}
+
+struct ScanStrgAllocator<'a, 'r> {
+    assets: &'a mut Vec<Resource<'r>>,
+    next_offset: &'a mut u32,
+    cache: HashMap<ScanStrgSpec, (ResId<res_id::SCAN>, ResId<res_id::STRG>)>,
+    local_savw_scans_to_add: &'a mut [Vec<ResId<res_id::SCAN>>],
+    savw_scan_logbook_category: &'a mut HashMap<u32, u32>,
+    version: Version,
+}
+
+impl ScanStrgAllocator<'_, '_> {
+    fn get_or_create(
+        &mut self,
+        world: World,
+        spec: ScanStrgSpec,
+    ) -> (ResId<res_id::SCAN>, ResId<res_id::STRG>) {
+        if let Some(&(scan_id, strg_id)) = self.cache.get(&spec) {
+            let world_savw = &mut self.local_savw_scans_to_add[world as usize];
+            if !world_savw.contains(&scan_id) {
+                world_savw.push(scan_id);
+            }
+
+            return (scan_id, strg_id);
+        }
+
+        let scan_id = ResId::<res_id::SCAN>::new(
+            custom_asset_ids::EXTRA_IDS_START.to_u32() + *self.next_offset,
+        );
+        *self.next_offset += 1;
+        let strg_id = ResId::<res_id::STRG>::new(
+            custom_asset_ids::EXTRA_IDS_START.to_u32() + *self.next_offset,
+        );
+        *self.next_offset += 1;
+
+        self.assets.extend_from_slice(&create_item_scan_strg_pair_2(
+            scan_id,
+            strg_id,
+            &spec,
+            self.version,
+        ));
+        self.local_savw_scans_to_add[world as usize].push(scan_id);
+        self.savw_scan_logbook_category
+            .insert(scan_id.to_u32(), spec.logbook_category);
+        self.cache.insert(spec, (scan_id, strg_id));
+
+        (scan_id, strg_id)
+    }
+}
+
+fn scan_strg_spec(config: &ScannableParametersConfig) -> ScanStrgSpec {
+    let mut strings = vec![config.intro.clone().unwrap_or_default() + "\0"];
+
+    if config.title.is_some() || config.body.is_some() {
+        strings.push(config.title.clone().unwrap_or_default() + "\0");
+    }
+
+    if let Some(body) = config.body.as_ref() {
+        strings.push(body.clone() + "\0");
+    }
+
+    ScanStrgSpec {
+        strings,
+        is_important: config.critical.unwrap_or(false) as u8,
+        logbook_category: config.logbook_category.unwrap_or_default() as u32,
+        scan_speed: config.slow_scan.unwrap_or(false) as u32,
+    }
+}
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct PickupHashKey {
@@ -600,6 +675,10 @@ pub fn custom_assets<'r>(
     pickup_hudmemos: &mut HashMap<PickupHashKey, ResId<res_id::STRG>>,
     pickup_scans: &mut HashMap<PickupHashKey, (ResId<res_id::SCAN>, ResId<res_id::STRG>)>,
     extra_scans: &mut HashMap<PickupHashKey, (ResId<res_id::SCAN>, ResId<res_id::STRG>)>,
+    edit_obj_scans: &mut HashMap<
+        ScannableParametersConfig,
+        (ResId<res_id::SCAN>, ResId<res_id::STRG>),
+    >,
     config: &PatchConfig,
 ) -> Result<
     (
@@ -631,12 +710,6 @@ pub fn custom_assets<'r>(
         Vec::new(),
         Vec::new(),
     ];
-
-    /* Mapping of strings and their corresponding scan_id. Use this to avoid
-       redundant usage of percious memory card space
-    */
-    let mut string_to_scan_strg: HashMap<String, (ResId<res_id::SCAN>, ResId<res_id::STRG>)> =
-        HashMap::new();
 
     /* Mapping of SCAN id to logbook category for easier SAVW entry creation */
     let mut savw_scan_logbook_category: HashMap<u32, u32> = HashMap::new();
@@ -721,26 +794,30 @@ pub fn custom_assets<'r>(
     assets.extend_from_slice(&create_item_scan_strg_pair_2(
         custom_asset_ids::CFLDG_POI_SCAN,
         custom_asset_ids::CFLDG_POI_STRG,
-        vec![
-            "Toaster's Champions: Awp82, DiggleWrath, Yeti2000, freak532486, AlphaRage, Csabi,\0".to_string(),
-            "\0".to_string(),
-            "BajaBlood, hammergoboom, Firemetroid, Lokir, MeriKatt, Cosmonawt, Haldadrin, RXM, Schwartz, Samuel, Miguel, chliu, JeffGainsNGames\0".to_string(),
-        ],
-        1,
-        0,
+        &ScanStrgSpec {
+            strings: vec![
+                "Toaster's Champions: Awp82, DiggleWrath, Yeti2000, freak532486, AlphaRage, Csabi,\0".to_string(),
+                "\0".to_string(),
+                "BajaBlood, hammergoboom, Firemetroid, Lokir, MeriKatt, Cosmonawt, Haldadrin, RXM, Schwartz, Samuel, Miguel, chliu, JeffGainsNGames\0".to_string(),
+            ],
+            is_important: 1,
+            ..Default::default()
+        },
         config.version,
     ));
     local_savw_scans_to_add[World::TallonOverworld as usize].push(custom_asset_ids::CFLDG_POI_SCAN);
     assets.extend_from_slice(&create_item_scan_strg_pair_2(
         custom_asset_ids::TOURNEY_WINNERS_SCAN,
         custom_asset_ids::TOURNEY_WINNERS_STRG,
-        vec![
-            "Chozo script translated.\0".to_string(),
-            "Racing\0".to_string(),
-            "As we have done for millennia, we Chozo work constantly on our speed. Our fastest are our sentinels; They are, and have always been, repositories for our most precious secrets and strongest powers.\n\n2025 - Samuel6710\n2024 (Mentor Tournament) - Belokuikuini\n2023 (CGC) - TheGingerChris + BajaBlood\n2023 - Cosmonawt\n2022 (CGC) - Cosmo + Cestrion\n2021 - Dinopony\n2020 - Interslice\n2019 - TheWeakestLink64\0".to_string(),
-        ],
-        1,
-        0,
+        &ScanStrgSpec {
+            strings: vec![
+                "Chozo script translated.\0".to_string(),
+                "Racing\0".to_string(),
+                "As we have done for millennia, we Chozo work constantly on our speed. Our fastest are our sentinels; They are, and have always been, repositories for our most precious secrets and strongest powers.\n\n2025 - Samuel6710\n2024 (Mentor Tournament) - Belokuikuini\n2023 (CGC) - TheGingerChris + BajaBlood\n2023 - Cosmonawt\n2022 (CGC) - Cosmo + Cestrion\n2021 - Dinopony\n2020 - Interslice\n2019 - TheWeakestLink64\0".to_string(),
+            ],
+            is_important: 1,
+            ..Default::default()
+        },
         config.version,
     ));
     local_savw_scans_to_add[World::TallonOverworld as usize]
@@ -762,9 +839,11 @@ pub fn custom_assets<'r>(
         assets.extend_from_slice(&create_item_scan_strg_pair_2(
             pt.scan(),
             pt.scan_strg(),
-            vec![format!("{}\0", name)],
-            1,
-            0,
+            &ScanStrgSpec {
+                strings: vec![format!("{}\0", name)],
+                is_important: 1,
+                ..Default::default()
+            },
             config.version,
         ));
         global_savw_scans_to_add.push(pt.scan());
@@ -780,92 +859,24 @@ pub fn custom_assets<'r>(
 
     // Create user-defined hudmemo and scan strings and map to locations //
     let mut custom_asset_offset = 0;
-    for (level_name, level) in config.level_data.iter() {
-        let world = World::from_json_key(level_name);
-        for (room_name, room) in level.rooms.iter() {
-            let mut pickup_idx = 0;
-            let mut extra_scans_idx = 0;
+    {
+        let mut scan_allocator = ScanStrgAllocator {
+            assets: &mut assets,
+            next_offset: &mut custom_asset_offset,
+            cache: HashMap::new(),
+            local_savw_scans_to_add: &mut local_savw_scans_to_add,
+            savw_scan_logbook_category: &mut savw_scan_logbook_category,
+            version: config.version,
+        };
 
-            if room.extra_scans.is_some() {
-                for custom_scan in room.extra_scans.as_ref().unwrap().iter() {
-                    let contents = &custom_scan.text;
+        for (level_name, level) in config.level_data.iter() {
+            let world = World::from_json_key(level_name);
+            for (room_name, room) in level.rooms.iter() {
+                let mut pickup_idx = 0;
+                let mut extra_scans_idx = 0;
 
-                    // Check if this string already has a scan_id //
-                    if string_to_scan_strg.contains_key(contents) {
-                        let (scan_id, strg_id) = string_to_scan_strg.get(contents).unwrap();
-
-                        // Add this scan_id as a dep of this world if it wasn't already //
-                        if !local_savw_scans_to_add[world as usize].contains(scan_id) {
-                            local_savw_scans_to_add[world as usize].push(*scan_id);
-                        }
-
-                        let key =
-                            PickupHashKey::from_location(level_name, room_name, extra_scans_idx);
-                        extra_scans.insert(key, (*scan_id, *strg_id));
-                        extra_scans_idx += 1;
-                        continue;
-                    }
-
-                    // Get next 2 IDs //
-                    let scan_id = ResId::<res_id::SCAN>::new(
-                        custom_asset_ids::EXTRA_IDS_START.to_u32() + custom_asset_offset,
-                    );
-                    custom_asset_offset += 1;
-                    let strg_id = ResId::<res_id::STRG>::new(
-                        custom_asset_ids::EXTRA_IDS_START.to_u32() + custom_asset_offset,
-                    );
-                    custom_asset_offset += 1;
-
-                    let is_red = {
-                        if *custom_scan.is_red.as_ref().unwrap_or(&false) {
-                            1
-                        } else {
-                            0
-                        }
-                    };
-
-                    let mut strings: Vec<String> = vec![];
-                    let mut contents = contents.to_string() + "\0";
-                    let mut content_len = contents.len();
-
-                    // "The &push;&main-color=#c300ff;Phazon Suit&pop; can be found in &push;&main-color=#89a1ff;Phazon Mines - Processing Center Access&pop;.",
-                    // TODO: the game will actually crash if we paginate the color wrong
-                    for x in contents.split('&') {
-                        let semicolon_index = x.find(';').unwrap_or(0);
-                        if semicolon_index != 0 {
-                            content_len -= semicolon_index + 2;
-                        }
-                    }
-
-                    let mut category = false;
-                    const PAGINATION_SIZE: usize = 123;
-                    while content_len > PAGINATION_SIZE {
-                        let mut i = PAGINATION_SIZE - 1;
-                        while contents.chars().nth(i).unwrap_or(' ') != ' ' {
-                            i -= 1;
-                        }
-
-                        i += 1;
-
-                        let page = (contents.clone().to_string())[..i].to_string();
-                        strings.push(page + "\0");
-
-                        contents = (contents.clone().to_string())[i..].to_string();
-                        content_len -= i;
-
-                        if !category {
-                            strings.push("\0".to_string()); // logbook category
-                            category = true;
-                        }
-                    }
-
-                    if content_len > 0 {
-                        strings.push(contents.clone() + "\0");
-                    }
-
-                    if !category {
-                        strings.push("\0".to_string()); // logbook category
-                    }
+                for custom_scan in room.extra_scans.iter().flatten() {
+                    let mut logbook_title = String::new();
 
                     if custom_scan.logbook_title.is_some() || custom_scan.logbook_category.is_some()
                     {
@@ -874,235 +885,103 @@ pub fn custom_assets<'r>(
                         {
                             panic!("Both logbook title and logbook category are required.");
                         }
-                        strings[1] = custom_scan.logbook_title.clone().unwrap() + "\0";
-                        savw_scan_logbook_category
-                            .insert(scan_id.to_u32(), custom_scan.logbook_category.unwrap());
+                        logbook_title = custom_scan.logbook_title.clone().unwrap();
                     }
 
-                    assets.extend_from_slice(&create_item_scan_strg_pair_2(
-                        scan_id,
-                        strg_id,
-                        strings,
-                        is_red,
-                        *custom_scan.logbook_category.as_ref().unwrap_or(&0),
-                        config.version,
-                    ));
+                    let spec = ScanStrgSpec {
+                        strings: vec![custom_scan.text.clone() + "\0", logbook_title + "\0"],
+                        is_important: custom_scan.is_red.unwrap_or(false) as u8,
+                        logbook_category: custom_scan.logbook_category.unwrap_or(0),
+                        ..Default::default()
+                    };
 
-                    // Map for easy lookup when patching //
                     let key = PickupHashKey::from_location(level_name, room_name, extra_scans_idx);
-                    extra_scans.insert(key, (scan_id, strg_id));
-                    local_savw_scans_to_add[world as usize].push(scan_id);
-
-                    // Cache this scan/strg pair for re-use //
-                    string_to_scan_strg.insert(contents, (scan_id, strg_id));
-
+                    extra_scans.insert(key, scan_allocator.get_or_create(world, spec));
                     extra_scans_idx += 1;
                 }
-            }
 
-            if room.doors.is_some() {
-                for (_, door) in room.doors.as_ref().unwrap().iter() {
-                    if door.destination.is_none() {
+                for door in room.doors.iter().flatten().map(|(_, door)| door) {
+                    let Some(destination) = door.destination.as_ref() else {
                         continue;
-                    }
+                    };
 
-                    let string = door.destination.as_ref().unwrap().room_name.clone() + "\0";
+                    let spec = ScanStrgSpec {
+                        strings: vec![destination.room_name.clone() + "\0"],
+                        ..Default::default()
+                    };
 
-                    // Check if this string already has a scan_id //
-                    if string_to_scan_strg.contains_key(&string.clone()) {
-                        let (scan_id, strg_id) = string_to_scan_strg.get(&string.clone()).unwrap();
+                    let key = PickupHashKey::from_location(level_name, room_name, extra_scans_idx);
+                    extra_scans.insert(key, scan_allocator.get_or_create(world, spec));
+                    extra_scans_idx += 1;
+                }
 
-                        // Add this scan_id as a dep of this world if it wasn't already //
-                        if !local_savw_scans_to_add[world as usize].contains(scan_id) {
-                            local_savw_scans_to_add[world as usize].push(*scan_id);
-                        }
+                for hudmemo_config in room.hudmemos.iter().flatten() {
+                    if let Some(text) = hudmemo_config.text.as_ref() {
+                        let spec = ScanStrgSpec {
+                            strings: vec![format!("{}\0", text)],
+                            ..Default::default()
+                        };
 
                         let key =
                             PickupHashKey::from_location(level_name, room_name, extra_scans_idx);
-                        extra_scans.insert(key, (*scan_id, *strg_id));
-                        extra_scans_idx += 1;
-
-                        continue;
+                        extra_scans.insert(key, scan_allocator.get_or_create(world, spec));
                     }
-
-                    // Get next 2 IDs //
-                    let scan_id = ResId::<res_id::SCAN>::new(
-                        custom_asset_ids::EXTRA_IDS_START.to_u32() + custom_asset_offset,
-                    );
-                    custom_asset_offset += 1;
-                    let strg_id = ResId::<res_id::STRG>::new(
-                        custom_asset_ids::EXTRA_IDS_START.to_u32() + custom_asset_offset,
-                    );
-                    custom_asset_offset += 1;
-
-                    // Create scan/strg pair for destination
-                    assets.extend_from_slice(&create_item_scan_strg_pair(
-                        scan_id,
-                        strg_id,
-                        string.clone(),
-                        config.version,
-                    ));
-                    local_savw_scans_to_add[world as usize].push(scan_id);
-
-                    // Map for easy lookup when patching //
-                    let key = PickupHashKey::from_location(level_name, room_name, extra_scans_idx);
-                    extra_scans.insert(key, (scan_id, strg_id));
-
-                    // Cache this scan/strg pair for re-use //
-                    string_to_scan_strg.insert(string.clone(), (scan_id, strg_id));
 
                     extra_scans_idx += 1;
                 }
-            }
 
-            if room.hudmemos.is_some() {
-                for hudmemo_config in room.hudmemos.as_ref().unwrap().iter() {
-                    if hudmemo_config.text.is_none() {
-                        extra_scans_idx += 1;
+                for edit_obj in room.edit_objs.iter().flatten().map(|(_, config)| config) {
+                    let Some(scannable_parameters) = edit_obj.scannable_parameters.as_ref() else {
                         continue;
-                    }
+                    };
 
-                    let string = format!("{}\0", hudmemo_config.text.as_ref().unwrap());
-
-                    // todo: subroutine
-
-                    // Check if this string already has a scan_id //
-                    if string_to_scan_strg.contains_key(&string.clone()) {
-                        let (scan_id, strg_id) = string_to_scan_strg.get(&string.clone()).unwrap();
-
-                        // Add this scan_id as a dep of this world if it wasn't already //
-                        if !local_savw_scans_to_add[world as usize].contains(scan_id) {
-                            local_savw_scans_to_add[world as usize].push(*scan_id);
-                        }
-
-                        let key =
-                            PickupHashKey::from_location(level_name, room_name, extra_scans_idx);
-                        extra_scans.insert(key, (*scan_id, *strg_id));
-                        extra_scans_idx += 1;
-
-                        continue;
-                    }
-
-                    // Get next 2 IDs //
-                    let scan_id = ResId::<res_id::SCAN>::new(
-                        custom_asset_ids::EXTRA_IDS_START.to_u32() + custom_asset_offset,
-                    );
-                    custom_asset_offset += 1;
-                    let strg_id = ResId::<res_id::STRG>::new(
-                        custom_asset_ids::EXTRA_IDS_START.to_u32() + custom_asset_offset,
-                    );
-                    custom_asset_offset += 1;
-
-                    // Create scan/strg pair for destination
-                    assets.extend_from_slice(&create_item_scan_strg_pair(
-                        scan_id,
-                        strg_id,
-                        string.clone(),
-                        config.version,
-                    ));
-                    local_savw_scans_to_add[world as usize].push(scan_id);
-
-                    // Map for easy lookup when patching //
-                    let key = PickupHashKey::from_location(level_name, room_name, extra_scans_idx);
-                    extra_scans.insert(key, (scan_id, strg_id));
-
-                    // Cache this scan/strg pair for re-use //
-                    string_to_scan_strg.insert(string.clone(), (scan_id, strg_id));
-
-                    extra_scans_idx += 1;
-                }
-            }
-
-            if room.pickups.is_none() {
-                continue;
-            };
-            for pickup in room.pickups.as_ref().unwrap().iter() {
-                // custom hudmemo string
-                if pickup.hudmemo_text.is_some() {
-                    let hudmemo_text = pickup.hudmemo_text.as_ref().unwrap();
-
-                    // Get next ID //
-                    let strg_id = ResId::<res_id::STRG>::new(
-                        custom_asset_ids::EXTRA_IDS_START.to_u32() + custom_asset_offset,
-                    );
-                    custom_asset_offset += 1;
-
-                    // Build resource //
-                    let strg = structs::ResourceKind::Strg(structs::Strg {
-                        string_tables: vec![structs::StrgStringTable {
-                            lang: b"ENGL".into(),
-                            strings: vec![format!("&just=center;{}\u{0}", hudmemo_text).into()]
-                                .into(),
-                        }]
-                        .into(),
-                    });
-                    let resource = build_resource(strg_id, strg);
-                    assets.push(resource);
-
-                    // Map for easy lookup when patching //
-                    let key = PickupHashKey::from_location(level_name, room_name, pickup_idx);
-                    pickup_hudmemos.insert(key, strg_id);
+                    let ids =
+                        scan_allocator.get_or_create(world, scan_strg_spec(scannable_parameters));
+                    edit_obj_scans.insert(scannable_parameters.clone(), ids);
                 }
 
-                // Custom scan string
-                if pickup.scan_text.is_some() {
-                    let scan_text = pickup.scan_text.as_ref().unwrap();
-
-                    // Check if this string already has a scan_id //
-                    if string_to_scan_strg.contains_key(scan_text) {
-                        let (scan_id, strg_id) = string_to_scan_strg.get(scan_text).unwrap();
-
-                        // Add this scan_id as a dep of this world if it wasn't already //
-                        if !local_savw_scans_to_add[world as usize].contains(scan_id) {
-                            local_savw_scans_to_add[world as usize].push(*scan_id);
-                        }
-
-                        // Map for easy lookup when patching //
-                        let key = PickupHashKey::from_location(level_name, room_name, pickup_idx);
-                        pickup_scans.insert(key, (*scan_id, *strg_id));
-                    } else {
-                        // Get next 2 IDs //
-                        let scan_id = ResId::<res_id::SCAN>::new(
-                            custom_asset_ids::EXTRA_IDS_START.to_u32() + custom_asset_offset,
-                        );
-                        custom_asset_offset += 1;
+                for pickup in room.pickups.iter().flatten() {
+                    // custom hudmemo string
+                    if let Some(hudmemo_text) = pickup.hudmemo_text.as_ref() {
+                        // Get next ID //
                         let strg_id = ResId::<res_id::STRG>::new(
-                            custom_asset_ids::EXTRA_IDS_START.to_u32() + custom_asset_offset,
+                            custom_asset_ids::EXTRA_IDS_START.to_u32()
+                                + *scan_allocator.next_offset,
                         );
-                        custom_asset_offset += 1;
+                        *scan_allocator.next_offset += 1;
 
                         // Build resource //
-                        if room_name.trim().to_lowercase() == "research core"
-                        // make the research core scan red because it goes on the terminal
-                        {
-                            assets.extend_from_slice(&create_item_scan_strg_pair_2(
-                                scan_id,
-                                strg_id,
-                                vec![format!("{}\0", scan_text)],
-                                1,
-                                0,
-                                config.version,
-                            ));
-                        } else {
-                            assets.extend_from_slice(&create_item_scan_strg_pair(
-                                scan_id,
-                                strg_id,
-                                format!("{}\0", scan_text),
-                                config.version,
-                            ));
-                        }
+                        let strg = structs::ResourceKind::Strg(structs::Strg {
+                            string_tables: vec![structs::StrgStringTable {
+                                lang: b"ENGL".into(),
+                                strings: vec![format!("&just=center;{}\u{0}", hudmemo_text).into()]
+                                    .into(),
+                            }]
+                            .into(),
+                        });
+                        scan_allocator.assets.push(build_resource(strg_id, strg));
 
                         // Map for easy lookup when patching //
                         let key = PickupHashKey::from_location(level_name, room_name, pickup_idx);
-                        pickup_scans.insert(key, (scan_id, strg_id));
-                        local_savw_scans_to_add[world as usize].push(scan_id);
-
-                        // Cache this scan/strg pair for re-use //
-                        string_to_scan_strg.insert(scan_text.to_string(), (scan_id, strg_id));
+                        pickup_hudmemos.insert(key, strg_id);
                     }
-                }
 
-                pickup_idx += 1;
+                    // Custom scan string
+                    if let Some(scan_text) = pickup.scan_text.as_ref() {
+                        let spec = ScanStrgSpec {
+                            strings: vec![format!("{}\0", scan_text)],
+                            // the research core scan is red because it goes on the terminal
+                            is_important: (room_name.trim().to_lowercase() == "research core")
+                                as u8,
+                            ..Default::default()
+                        };
+
+                        let key = PickupHashKey::from_location(level_name, room_name, pickup_idx);
+                        pickup_scans.insert(key, scan_allocator.get_or_create(world, spec));
+                    }
+
+                    pickup_idx += 1;
+                }
             }
         }
     }
@@ -1168,9 +1047,11 @@ pub fn custom_assets<'r>(
                 assets.extend_from_slice(&create_item_scan_strg_pair_2(
                     door_type.scan(),
                     door_type.strg(),
-                    door_type.scan_text(),
-                    1,
-                    0,
+                    &ScanStrgSpec {
+                        strings: door_type.scan_text(),
+                        is_important: 1,
+                        ..Default::default()
+                    },
                     config.version,
                 ));
                 global_savw_scans_to_add.push(door_type.scan());
@@ -1200,9 +1081,11 @@ pub fn custom_assets<'r>(
                 assets.extend_from_slice(&create_item_scan_strg_pair_2(
                     blast_shield.scan(),
                     blast_shield.strg(),
-                    blast_shield.scan_text(),
-                    1,
-                    0,
+                    &ScanStrgSpec {
+                        strings: blast_shield.scan_text(),
+                        is_important: 1,
+                        ..Default::default()
+                    },
                     config.version,
                 ));
                 global_savw_scans_to_add.push(blast_shield.scan());
@@ -1256,6 +1139,7 @@ pub fn collect_game_resources<'r>(
         HashMap<PickupHashKey, ResId<res_id::STRG>>,
         HashMap<PickupHashKey, (ResId<res_id::SCAN>, ResId<res_id::STRG>)>,
         HashMap<PickupHashKey, (ResId<res_id::SCAN>, ResId<res_id::STRG>)>,
+        HashMap<ScannableParametersConfig, (ResId<res_id::SCAN>, ResId<res_id::STRG>)>,
         Vec<ResId<res_id::SCAN>>,
         Vec<Vec<ResId<res_id::SCAN>>>,
         HashMap<u32, u32>,
@@ -1416,6 +1300,8 @@ pub fn collect_game_resources<'r>(
         HashMap::<PickupHashKey, (ResId<res_id::SCAN>, ResId<res_id::STRG>)>::new();
     let mut extra_scans =
         HashMap::<PickupHashKey, (ResId<res_id::SCAN>, ResId<res_id::STRG>)>::new();
+    let mut edit_obj_scans =
+        HashMap::<ScannableParametersConfig, (ResId<res_id::SCAN>, ResId<res_id::STRG>)>::new();
 
     // Remove extra assets from dependency search since they won't appear     //
     // in any pak. Instead add them to the output resource pool. These assets //
@@ -1432,6 +1318,7 @@ pub fn collect_game_resources<'r>(
         &mut pickup_hudmemos,
         &mut pickup_scans,
         &mut extra_scans,
+        &mut edit_obj_scans,
         config,
     )?;
     for res in custom_assets.iter() {
@@ -1449,6 +1336,7 @@ pub fn collect_game_resources<'r>(
         pickup_hudmemos,
         pickup_scans,
         extra_scans,
+        edit_obj_scans,
         global_savw_scans_to_add,
         local_savw_scans_to_add,
         savw_scan_logbook_category,
@@ -1984,15 +1872,18 @@ fn create_item_scan_strg_pair<'r>(
     contents: String,
     version: Version,
 ) -> [structs::Resource<'r>; 2] {
-    create_item_scan_strg_pair_2(new_scan, new_strg, vec![contents], 0, 0, version)
+    let spec = ScanStrgSpec {
+        strings: vec![contents],
+        ..Default::default()
+    };
+
+    create_item_scan_strg_pair_2(new_scan, new_strg, &spec, version)
 }
 
 fn create_item_scan_strg_pair_2<'r>(
     new_scan: ResId<res_id::SCAN>,
     new_strg: ResId<res_id::STRG>,
-    contents: Vec<String>,
-    is_important: u8,
-    logbook_category: u32,
+    spec: &ScanStrgSpec,
     version: Version,
 ) -> [structs::Resource<'r>; 2] {
     let scan = build_resource(
@@ -2000,9 +1891,9 @@ fn create_item_scan_strg_pair_2<'r>(
         structs::ResourceKind::Scan(structs::Scan {
             frme: ResId::<res_id::FRME>::new(0xDCEC3E77),
             strg: new_strg,
-            scan_speed: 0,
-            category: logbook_category,
-            icon_flag: is_important,
+            scan_speed: spec.scan_speed,
+            category: spec.logbook_category,
+            icon_flag: spec.is_important,
             images: [
                 structs::ScanImage {
                     txtr: ResId::invalid(),
@@ -2047,6 +1938,7 @@ fn create_item_scan_strg_pair_2<'r>(
         }),
     );
 
+    let contents = spec.strings.clone();
     let kind = if version == Version::Pal {
         structs::ResourceKind::Strg(structs::Strg::from_strings_pal(contents))
     } else if version == Version::NtscJ {

--- a/src/generic_edit.rs
+++ b/src/generic_edit.rs
@@ -1,16 +1,24 @@
 use std::collections::HashMap;
 
-use reader_writer::CStrConversionExtension;
+use reader_writer::{CStrConversionExtension, FourCC};
+use structs::{res_id, Dependency, ResId};
 
 use crate::{
-    door_meta::DoorType, mlvl_wrapper, patch_config::EditObjConfig, patcher::PatcherState,
+    door_meta::DoorType,
+    mlvl_wrapper,
+    patch_config::{EditObjConfig, ScannableParametersConfig},
+    patcher::PatcherState,
     structs::SclyPropertyData,
 };
 
-pub fn patch_edit_objects(
+const SCAN_FRME: ResId<res_id::FRME> = ResId::new(0xDCEC3E77);
+
+pub fn patch_edit_objects<'r>(
     _ps: &mut PatcherState,
-    area: &mut mlvl_wrapper::MlvlArea,
+    area: &mut mlvl_wrapper::MlvlArea<'r, '_, '_, '_>,
     edit_objs: HashMap<u32, EditObjConfig>,
+    game_resources: &HashMap<(u32, FourCC), structs::Resource<'r>>,
+    edit_obj_scans: &HashMap<ScannableParametersConfig, (ResId<res_id::SCAN>, ResId<res_id::STRG>)>,
 ) -> Result<(), String> {
     let mrea_id = area.mlvl_area.mrea.to_u32();
 
@@ -98,6 +106,8 @@ pub fn patch_edit_objects(
     }
 
     /* Edit Properties */
+
+    let mut scans_to_add: Vec<(ResId<res_id::SCAN>, ResId<res_id::STRG>)> = Vec::new();
 
     let scly = area.mrea().scly_section_mut();
 
@@ -222,6 +232,23 @@ pub fn patch_edit_objects(
                 set_health(obj, *value, Some(*index as usize));
             }
         }
+
+        if let Some(value) = &config.scannable_parameters {
+            let ids = edit_obj_scans.get(value).unwrap_or_else(|| {
+                panic!(
+                    "No scan was built for object 0x{:X} in room 0x{:X}",
+                    id, mrea_id
+                )
+            });
+
+            set_scannable_parameters(obj, ids.0);
+            scans_to_add.push(*ids);
+        }
+    }
+
+    for (scan_id, strg_id) in scans_to_add {
+        let deps: [Dependency; 3] = [scan_id.into(), strg_id.into(), SCAN_FRME.into()];
+        area.add_dependencies(game_resources, 0, deps.into_iter());
     }
 
     Ok(())
@@ -405,6 +432,23 @@ pub fn set_health(obj: &mut structs::SclyObject, value: f32, index: Option<usize
             obj.instance_id
         );
     }
+}
+
+pub fn set_scannable_parameters(obj: &mut structs::SclyObject, scan: ResId<res_id::SCAN>) {
+    if !obj.property_data.supports_scannable_parameters() {
+        panic!(
+            "object 0x{:X} does not support property \"scannableParameters\"",
+            obj.instance_id
+        );
+    }
+
+    let count = obj.property_data.get_scannable_parameters().len();
+    obj.property_data.set_scannable_parameters(vec![
+        structs::scly_structs::ScannableParameters {
+            scan
+        };
+        count
+    ]);
 }
 
 pub fn set_damage(obj: &mut structs::SclyObject, value: f32) {

--- a/src/patch_config.rs
+++ b/src/patch_config.rs
@@ -17,8 +17,12 @@ use serde::{
 use structs::{res_id, MapaObjectVisibilityMode, ResId};
 
 use crate::{
-    custom_assets::custom_asset_ids, door_meta::DoorType, elevators::World,
-    pickup_meta::PickupType, room_lookup::ROOM_BY_INTERNAL_ID, starting_items::StartingItems,
+    custom_assets::custom_asset_ids,
+    door_meta::DoorType,
+    elevators::World,
+    pickup_meta::{self, PickupType},
+    room_lookup::ROOM_BY_INTERNAL_ID,
+    starting_items::StartingItems,
 };
 
 /*** Parsed Config (fn patch_iso) ***/
@@ -545,6 +549,30 @@ pub struct StreamedAudioConfig {
     pub is_music: bool,
 }
 
+#[derive(PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Copy, Clone, Default)]
+#[serde(deny_unknown_fields)]
+#[repr(u32)]
+pub enum LogbookCategory {
+    #[default]
+    None,
+    PirateData,
+    ChozoLore,
+    Creatures,
+    Research,
+    Artifacts,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ScannableParametersConfig {
+    pub logbook_category: Option<LogbookCategory>,
+    pub title: Option<String>,
+    pub intro: Option<String>,
+    pub body: Option<String>,
+    pub critical: Option<bool>,
+    pub slow_scan: Option<bool>,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EditObjConfig {
@@ -562,6 +590,7 @@ pub struct EditObjConfig {
     pub vulnerabilities: Option<HashMap<u32, String>>,
     pub health: Option<f32>,
     pub healths: Option<HashMap<u32, f32>>,
+    pub scannable_parameters: Option<ScannableParametersConfig>,
 }
 
 // None = 0,
@@ -2264,6 +2293,20 @@ impl PatchConfigPrivate {
                                     }
                                 }
 
+                                if let Some(other_scan) = &other_config.scannable_parameters {
+                                    match &self_config.scannable_parameters {
+                                        Some(self_scan) => {
+                                            if self_scan != other_scan {
+                                                panic!("Conflict in {}'s editObjs", room_name);
+                                            }
+                                        }
+                                        None => {
+                                            self_config.scannable_parameters =
+                                                Some(other_scan.clone());
+                                        }
+                                    }
+                                }
+
                                 if let Some(other_healths) = &other_config.healths {
                                     match self_config.healths.as_mut() {
                                         Some(self_healths) => {
@@ -2298,6 +2341,41 @@ impl PatchConfigPrivate {
                 }
             }
         }
+    }
+
+    fn validate_level_data(&self) -> Result<(), String> {
+        let mut rooms_by_world: HashMap<&str, HashSet<&str>> = HashMap::new();
+        for (pak_name, rooms) in pickup_meta::ROOM_INFO.iter() {
+            let world = World::from_pak(pak_name).unwrap();
+            rooms_by_world
+                .entry(world.to_json_key())
+                .or_default()
+                .extend(rooms.iter().map(|room| room.name().trim()));
+        }
+
+        for (world_key, level) in self.level_data.iter() {
+            let rooms = rooms_by_world.get(world_key.as_str()).ok_or_else(|| {
+                format!(
+                    "'{}' in levelData is not a world. Expected one of: {}",
+                    world_key,
+                    World::iter()
+                        .map(|world| world.to_json_key())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            })?;
+
+            for room_name in level.rooms.keys() {
+                if !rooms.contains(room_name.as_str()) {
+                    return Err(format!(
+                        "'{}' in levelData is not a room in {}",
+                        room_name, world_key
+                    ));
+                }
+            }
+        }
+
+        Ok(())
     }
 
     // parse and then handle configuration macros (e.g. a bool loading in several pages of JSON changes)
@@ -2386,6 +2464,8 @@ impl PatchConfigPrivate {
     }
 
     fn parse_inner(&self, version: Version) -> Result<PatchConfig, String> {
+        self.validate_level_data()?;
+
         let run_mode = {
             if self.run_mode.is_some() {
                 match self.run_mode.as_ref().unwrap().to_lowercase().trim() {

--- a/src/patch_config.rs
+++ b/src/patch_config.rs
@@ -562,15 +562,19 @@ pub enum LogbookCategory {
     Artifacts,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ScannableParametersConfig {
-    pub logbook_category: Option<LogbookCategory>,
-    pub title: Option<String>,
-    pub intro: Option<String>,
-    pub body: Option<String>,
-    pub critical: Option<bool>,
-    pub slow_scan: Option<bool>,
+    #[serde(default)]
+    pub logbook_category: LogbookCategory,
+    #[serde(default)]
+    pub title: String,
+    pub intro: String,
+    pub body: String,
+    #[serde(default)]
+    pub critical: bool,
+    #[serde(default)]
+    pub slow_scan: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -14932,7 +14932,7 @@ fn export_assets(gc_disc: &mut structs::GcDisc, config: &PatchConfig) -> Result<
         }
     }
 
-    let (_, _, _, _, _, _, _, _, custom_assets) = collect_game_resources(gc_disc, None, config)?;
+    let (_, _, _, _, _, _, _, _, _, custom_assets) = collect_game_resources(gc_disc, None, config)?;
 
     for resource in custom_assets {
         let mut bytes = vec![];
@@ -15139,6 +15139,7 @@ fn build_and_run_patches<'r>(
         pickup_hudmemos,
         pickup_scans,
         extra_scans,
+        edit_obj_scans,
         savw_scans_to_add,
         local_savw_scans_to_add,
         savw_scan_logbook_category,
@@ -15151,6 +15152,7 @@ fn build_and_run_patches<'r>(
     let pickup_hudmemos = &pickup_hudmemos;
     let pickup_scans = &pickup_scans;
     let extra_scans = &extra_scans;
+    let edit_obj_scans = &edit_obj_scans;
     let strgs = config.strg.clone();
     let strgs = &strgs;
 
@@ -17808,7 +17810,7 @@ fn build_and_run_patches<'r>(
 
         if let Some(edit_objs) = room_config.edit_objs.as_ref() {
             patcher.add_scly_patch(*room, move |ps, area| {
-                patch_edit_objects(ps, area, edit_objs.clone())
+                patch_edit_objects(ps, area, edit_objs.clone(), game_resources, edit_obj_scans)
             });
         }
 

--- a/structs/src/scly.rs
+++ b/structs/src/scly.rs
@@ -8,7 +8,9 @@ use reader_writer::{
 
 use crate::{
     scly_props,
-    scly_structs::{DamageInfo, DamageVulnerability, HealthInfo, PatternedInfo},
+    scly_structs::{
+        DamageInfo, DamageVulnerability, HealthInfo, PatternedInfo, ScannableParameters,
+    },
 };
 
 #[macro_export]
@@ -147,6 +149,40 @@ macro_rules! impl_patterned_info_with_auxillary {
 
         fn impl_set_health_infos(&mut self, x: Vec<HealthInfo>) {
             self.patterned_info.health_info = x[0].clone();
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_scannable_parameters {
+    ($($($field:ident).+),+ $(,)?) => {
+        const SUPPORTS_SCANNABLE_PARAMETERS: bool = true;
+
+        fn impl_get_scannable_parameters(&self) -> Vec<$crate::scly_structs::ScannableParameters> {
+            vec![$(self.$($field).+.clone()),+]
+        }
+
+        fn impl_set_scannable_parameters(&mut self, x: Vec<$crate::scly_structs::ScannableParameters>) {
+            let mut x = x.into_iter();
+            $(self.$($field).+ = x.next().unwrap();)+
+        }
+    };
+}
+
+/// Same as `impl_scannable_parameters!`, but for the far more common case of the
+/// `ScannableParameters` being reached through an `ActorParameters` field.
+#[macro_export]
+macro_rules! impl_actor_scannable_parameters {
+    ($($($field:ident).+),+ $(,)?) => {
+        const SUPPORTS_SCANNABLE_PARAMETERS: bool = true;
+
+        fn impl_get_scannable_parameters(&self) -> Vec<$crate::scly_structs::ScannableParameters> {
+            vec![$(self.$($field).+.scan_parameters.clone()),+]
+        }
+
+        fn impl_set_scannable_parameters(&mut self, x: Vec<$crate::scly_structs::ScannableParameters>) {
+            let mut x = x.into_iter();
+            $(self.$($field).+.scan_parameters = x.next().unwrap();)+
         }
     };
 }
@@ -609,6 +645,44 @@ macro_rules! build_scly_property {
                     $(
                         SclyProperty::$name(_) => {
                             self.$accessor_mut().unwrap().impl_set_health_infos(x);
+                        },
+                    )*
+                }
+            }
+
+            /* Scannable Parameters */
+
+            pub fn supports_scannable_parameters(&self) -> bool {
+                let object_type = self.object_type();
+                #[allow(unreachable_patterns)] // ridley throws a warning because we have both PAL and NTSC ridley definitions
+                match object_type {
+                    $(<scly_props::$name as SclyPropertyData>::OBJECT_TYPE => <scly_props::$name as SclyPropertyData>::SUPPORTS_SCANNABLE_PARAMETERS,)*
+                    _ => false,
+                }
+            }
+
+            pub fn get_scannable_parameters(&mut self) -> Vec<ScannableParameters>
+            {
+                self.guess_kind();
+                match *self {
+                    SclyProperty::Unknown { object_type, .. } => panic!("0x{:X} doesn't support scannable parameters (get)", object_type),
+                    $(
+                        SclyProperty::$name(_) => {
+                            let prop = self.$accessor();
+                            prop.unwrap().impl_get_scannable_parameters()
+                        },
+                    )*
+                }
+            }
+
+            pub fn set_scannable_parameters(&mut self, x: Vec<ScannableParameters>)
+            {
+                self.guess_kind();
+                match *self {
+                    SclyProperty::Unknown { object_type, .. } => panic!("0x{:X} doesn't support scannable parameters (set)", object_type),
+                    $(
+                        SclyProperty::$name(_) => {
+                            self.$accessor_mut().unwrap().impl_set_scannable_parameters(x);
                         },
                     )*
                 }
@@ -1413,6 +1487,23 @@ pub trait SclyPropertyData {
     fn impl_set_health_infos(&mut self, _: Vec<HealthInfo>) {
         panic!(
             "Script object type 0x{:X} does not implement the 'Vulnerabilities' property",
+            Self::OBJECT_TYPE
+        )
+    }
+
+    /* Scannable Parameters */
+    const SUPPORTS_SCANNABLE_PARAMETERS: bool = false;
+
+    fn impl_get_scannable_parameters(&self) -> Vec<ScannableParameters> {
+        panic!(
+            "Script object type 0x{:X} does not implement the 'Scannable Parameters' property",
+            Self::OBJECT_TYPE
+        )
+    }
+
+    fn impl_set_scannable_parameters(&mut self, _: Vec<ScannableParameters>) {
+        panic!(
+            "Script object type 0x{:X} does not implement the 'Scannable Parameters' property",
             Self::OBJECT_TYPE
         )
     }

--- a/structs/src/scly_props/actor.rs
+++ b/structs/src/scly_props/actor.rs
@@ -44,13 +44,17 @@ pub struct Actor<'r> {
     pub material_flag_54: u8,
 }
 
-use crate::{impl_active, impl_position, impl_rotation, impl_scale};
+use crate::{
+    impl_active, impl_actor_scannable_parameters, impl_position, impl_rotation, impl_scale,
+};
 impl SclyPropertyData for Actor<'_> {
     const OBJECT_TYPE: u8 = 0x0;
     impl_active!();
     impl_position!();
     impl_rotation!();
     impl_scale!();
+
+    impl_actor_scannable_parameters!(actor_parameters);
 
     const SUPPORTS_VULNERABILITIES: bool = true;
 

--- a/structs/src/scly_props/actor_contraption.rs
+++ b/structs/src/scly_props/actor_contraption.rs
@@ -30,7 +30,9 @@ pub struct ActorContraption<'r> {
     pub active: u8,
 }
 
-use crate::{impl_active, impl_position, impl_rotation, impl_scale};
+use crate::{
+    impl_active, impl_actor_scannable_parameters, impl_position, impl_rotation, impl_scale,
+};
 impl SclyPropertyData for ActorContraption<'_> {
     const OBJECT_TYPE: u8 = 0x6E;
 
@@ -38,6 +40,8 @@ impl SclyPropertyData for ActorContraption<'_> {
     impl_position!();
     impl_rotation!();
     impl_scale!();
+
+    impl_actor_scannable_parameters!(actor_params);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/ambient_ai.rs
+++ b/structs/src/scly_props/ambient_ai.rs
@@ -2,7 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_active, impl_position, impl_rotation, impl_scale, scly_props::structs::*, SclyPropertyData,
+    impl_active, impl_actor_scannable_parameters, impl_position, impl_rotation, impl_scale,
+    scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -22,13 +23,12 @@ pub struct AmbientAI<'r> {
     pub health_info: HealthInfo,
     pub damage_vulnerability: DamageVulnerability,
     pub animation_params: AnimationParameters,
+    pub actor_params: ActorParameters,
     pub alert_range: f32,
     pub impact_range: f32,
     pub alert_anim: u32,
     pub impact_anim: u32,
     pub active: u8,
-
-    pub dont_care: GenericArray<u8, U125>,
 }
 
 impl SclyPropertyData for AmbientAI<'_> {
@@ -37,6 +37,7 @@ impl SclyPropertyData for AmbientAI<'_> {
     impl_active!();
     impl_position!();
     impl_rotation!();
+    impl_actor_scannable_parameters!(actor_params);
     impl_scale!(); // TODO: scale should also affect collision extent and mass
 
     const SUPPORTS_VULNERABILITIES: bool = true;

--- a/structs/src/scly_props/atomic_alpha.rs
+++ b/structs/src/scly_props/atomic_alpha.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info, impl_position, impl_rotation, impl_scale, scly_props::structs::*,
-    SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+    scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -36,6 +36,8 @@ impl SclyPropertyData for AtomicAlpha<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_params);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/atomic_beta.rs
+++ b/structs/src/scly_props/atomic_beta.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info, impl_position, impl_rotation, impl_scale, scly_props::structs::*,
-    SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+    scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -44,6 +44,8 @@ impl SclyPropertyData for AtomicBeta<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_params);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/babygoth.rs
+++ b/structs/src/scly_props/babygoth.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info, impl_position, impl_rotation, impl_scale, scly_props::structs::*,
-    SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+    scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -56,6 +56,8 @@ impl SclyPropertyData for Babygoth<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_params);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/beetle.rs
+++ b/structs/src/scly_props/beetle.rs
@@ -30,7 +30,9 @@ pub struct Beetle<'r> {
     pub retreat_time: f32,
 }
 
-use crate::{impl_patterned_info, impl_position, impl_rotation, impl_scale};
+use crate::{
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+};
 impl SclyPropertyData for Beetle<'_> {
     const OBJECT_TYPE: u8 = 0x16;
 
@@ -38,6 +40,8 @@ impl SclyPropertyData for Beetle<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_params);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/bloodflower.rs
+++ b/structs/src/scly_props/bloodflower.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info, impl_position, impl_rotation, impl_scale, scly_props::structs::*,
-    SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+    scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -40,6 +40,8 @@ impl SclyPropertyData for Bloodflower<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_params);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/burrower.rs
+++ b/structs/src/scly_props/burrower.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info, impl_position, impl_rotation, impl_scale, scly_props::structs::*,
-    SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+    scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -35,6 +35,8 @@ impl SclyPropertyData for Burrower<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_params);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/chozo_ghost.rs
+++ b/structs/src/scly_props/chozo_ghost.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info, impl_position, impl_rotation, impl_scale, scly_props::structs::*,
-    SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+    scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -51,6 +51,8 @@ impl SclyPropertyData for ChozoGhost<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_params);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/debris.rs
+++ b/structs/src/scly_props/debris.rs
@@ -2,7 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_active, impl_position, impl_rotation, impl_scale, scly_props::structs::*, SclyPropertyData,
+    impl_active, impl_actor_scannable_parameters, impl_position, impl_rotation, impl_scale,
+    scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -33,4 +34,5 @@ impl SclyPropertyData for Debris<'_> {
     impl_position!();
     impl_rotation!();
     impl_scale!();
+    impl_actor_scannable_parameters!(actor_params);
 }

--- a/structs/src/scly_props/debris_extended.rs
+++ b/structs/src/scly_props/debris_extended.rs
@@ -2,7 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_active, impl_position, impl_rotation, impl_scale, scly_props::structs::*, SclyPropertyData,
+    impl_active, impl_actor_scannable_parameters, impl_position, impl_rotation, impl_scale,
+    scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -38,4 +39,5 @@ impl SclyPropertyData for DebrisExtended<'_> {
     impl_position!();
     impl_rotation!();
     impl_scale!();
+    impl_actor_scannable_parameters!(actor_params);
 }

--- a/structs/src/scly_props/door.rs
+++ b/structs/src/scly_props/door.rs
@@ -32,7 +32,9 @@ pub struct Door<'r> {
     pub is_morphball_door: u8,
 }
 
-use crate::{impl_active, impl_position, impl_rotation, impl_scale};
+use crate::{
+    impl_active, impl_actor_scannable_parameters, impl_position, impl_rotation, impl_scale,
+};
 impl SclyPropertyData for Door<'_> {
     const OBJECT_TYPE: u8 = 0x03;
 
@@ -40,4 +42,5 @@ impl SclyPropertyData for Door<'_> {
     impl_position!();
     impl_rotation!();
     impl_scale!();
+    impl_actor_scannable_parameters!(actor_parameters);
 }

--- a/structs/src/scly_props/drone.rs
+++ b/structs/src/scly_props/drone.rs
@@ -28,7 +28,9 @@ pub struct Drone<'r> {
     pub dont_care: GenericArray<u8, U273>,
 }
 
-use crate::{impl_patterned_info, impl_position, impl_rotation, impl_scale};
+use crate::{
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+};
 impl SclyPropertyData for Drone<'_> {
     const OBJECT_TYPE: u8 = 0x43;
 
@@ -36,6 +38,8 @@ impl SclyPropertyData for Drone<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_params);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/elite_pirate.rs
+++ b/structs/src/scly_props/elite_pirate.rs
@@ -53,7 +53,9 @@ pub struct ElitePirate<'r> {
     pub unknown18: u8,
 }
 
-use crate::{impl_patterned_info, impl_position, impl_rotation, impl_scale};
+use crate::{
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+};
 impl SclyPropertyData for ElitePirate<'_> {
     const OBJECT_TYPE: u8 = 0x26;
 
@@ -61,6 +63,8 @@ impl SclyPropertyData for ElitePirate<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_params, actor_params2);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/energy_ball.rs
+++ b/structs/src/scly_props/energy_ball.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info, impl_position, impl_rotation, impl_scale, scly_props::structs::*,
-    SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+    scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -43,6 +43,8 @@ impl SclyPropertyData for EnergyBall<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_params);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/eyeball.rs
+++ b/structs/src/scly_props/eyeball.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info, impl_position, impl_rotation, impl_scale, scly_props::structs::*,
-    SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+    scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -38,6 +38,8 @@ impl SclyPropertyData for Eyeball<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_params);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/fire_flea.rs
+++ b/structs/src/scly_props/fire_flea.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info_with_auxillary, impl_position, impl_rotation, impl_scale,
-    scly_props::structs::*, SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info_with_auxillary, impl_position,
+    impl_rotation, impl_scale, scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -33,4 +33,5 @@ impl SclyPropertyData for FireFlea<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info_with_auxillary!();
+    impl_actor_scannable_parameters!(actor_params);
 }

--- a/structs/src/scly_props/flaahgra.rs
+++ b/structs/src/scly_props/flaahgra.rs
@@ -39,7 +39,9 @@ pub struct Flaahgra<'r> {
     pub dont_care6: u32,
 }
 
-use crate::{impl_patterned_info, impl_position, impl_rotation, impl_scale};
+use crate::{
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+};
 impl SclyPropertyData for Flaahgra<'_> {
     const OBJECT_TYPE: u8 = 0x4D;
 
@@ -47,6 +49,8 @@ impl SclyPropertyData for Flaahgra<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_params1, actor_params2);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/flaahgra_tentacle.rs
+++ b/structs/src/scly_props/flaahgra_tentacle.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info_with_auxillary, impl_position, impl_rotation, impl_scale,
-    scly_props::structs::*, SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info_with_auxillary, impl_position,
+    impl_rotation, impl_scale, scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -29,4 +29,5 @@ impl SclyPropertyData for FlaahgraTentacle<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info_with_auxillary!();
+    impl_actor_scannable_parameters!(actor_params);
 }

--- a/structs/src/scly_props/flicker_bat.rs
+++ b/structs/src/scly_props/flicker_bat.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info_with_auxillary, impl_position, impl_rotation, impl_scale,
-    scly_props::structs::*, SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info_with_auxillary, impl_position,
+    impl_rotation, impl_scale, scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -35,4 +35,5 @@ impl SclyPropertyData for FlickerBat<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info_with_auxillary!();
+    impl_actor_scannable_parameters!(actor_params);
 }

--- a/structs/src/scly_props/flying_pirate.rs
+++ b/structs/src/scly_props/flying_pirate.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info, impl_position, impl_rotation, impl_scale, scly_props::structs::*,
-    SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+    scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -45,6 +45,8 @@ impl SclyPropertyData for FlyingPirate<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_params);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/geemer.rs
+++ b/structs/src/scly_props/geemer.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info_with_auxillary, impl_position, impl_rotation, impl_scale,
-    scly_props::structs::*, SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info_with_auxillary, impl_position,
+    impl_rotation, impl_scale, scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -31,4 +31,5 @@ impl SclyPropertyData for Geemer<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info_with_auxillary!();
+    impl_actor_scannable_parameters!(actor_params);
 }

--- a/structs/src/scly_props/gun_turret.rs
+++ b/structs/src/scly_props/gun_turret.rs
@@ -1,7 +1,10 @@
 use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
-use crate::{impl_position, impl_rotation, impl_scale, scly_props::structs::*, SclyPropertyData};
+use crate::{
+    impl_actor_scannable_parameters, impl_position, impl_rotation, impl_scale,
+    scly_props::structs::*, SclyPropertyData,
+};
 
 #[auto_struct(Readable, Writable)]
 #[derive(Debug, Clone, PartialEq)]
@@ -39,6 +42,8 @@ impl SclyPropertyData for GunTurret<'_> {
     impl_position!();
     impl_rotation!();
     impl_scale!();
+
+    impl_actor_scannable_parameters!(actor_params);
 
     const SUPPORTS_VULNERABILITIES: bool = true;
 

--- a/structs/src/scly_props/ice_sheegoth.rs
+++ b/structs/src/scly_props/ice_sheegoth.rs
@@ -35,7 +35,9 @@ pub struct IceSheegoth<'r> {
     pub dont_care6: u8,
 }
 
-use crate::{impl_patterned_info, impl_position, impl_rotation, impl_scale};
+use crate::{
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+};
 impl SclyPropertyData for IceSheegoth<'_> {
     const OBJECT_TYPE: u8 = 0x4B;
 
@@ -43,6 +45,8 @@ impl SclyPropertyData for IceSheegoth<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_params);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/jelly_zap.rs
+++ b/structs/src/scly_props/jelly_zap.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info, impl_position, impl_rotation, impl_scale, scly_props::structs::*,
-    SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+    scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -32,6 +32,8 @@ impl SclyPropertyData for JellyZap<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_parameters);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/magdolite.rs
+++ b/structs/src/scly_props/magdolite.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info, impl_position, impl_rotation, impl_scale, scly_props::structs::*,
-    SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+    scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -46,6 +46,8 @@ impl SclyPropertyData for Magdolite<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_parameters);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/metaree.rs
+++ b/structs/src/scly_props/metaree.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info, impl_position, impl_rotation, impl_scale, scly_props::structs::*,
-    SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+    scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -32,6 +32,8 @@ impl SclyPropertyData for Metaree<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_parameters);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/metroid.rs
+++ b/structs/src/scly_props/metroid.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info, impl_position, impl_rotation, impl_scale, scly_props::structs::*,
-    SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+    scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -39,6 +39,8 @@ impl SclyPropertyData for Metroid<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_parameters);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/metroid_beta.rs
+++ b/structs/src/scly_props/metroid_beta.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info, impl_position, impl_rotation, impl_scale, scly_props::structs::*,
-    SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+    scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -34,6 +34,8 @@ impl SclyPropertyData for MetroidBeta<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_parameters);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/metroidprimestage1.rs
+++ b/structs/src/scly_props/metroidprimestage1.rs
@@ -142,13 +142,17 @@ pub struct ExoProjectileInfo {
     pub dont_cares2: GenericArray<u8, U4>,
 }
 
-use crate::{impl_active, impl_position, impl_rotation, impl_scale};
+use crate::{
+    impl_active, impl_actor_scannable_parameters, impl_position, impl_rotation, impl_scale,
+};
 impl SclyPropertyData for MetroidPrimeStage1<'_> {
     const OBJECT_TYPE: u8 = 0x84;
 
     impl_position!();
     impl_rotation!();
     impl_scale!();
+
+    impl_actor_scannable_parameters!(exo_struct_b.actor_params);
 
     const SUPPORTS_ACTIVE: bool = true;
 

--- a/structs/src/scly_props/metroidprimestage2.rs
+++ b/structs/src/scly_props/metroidprimestage2.rs
@@ -29,13 +29,17 @@ pub struct MetroidPrimeStage2<'r> {
     pub part2: ResId<PART>,
 }
 
-use crate::{impl_patterned_info, impl_position, impl_rotation, impl_scale};
+use crate::{
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+};
 impl SclyPropertyData for MetroidPrimeStage2<'_> {
     const OBJECT_TYPE: u8 = 0x83;
     impl_position!();
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_parameters);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/new_intro_boss.rs
+++ b/structs/src/scly_props/new_intro_boss.rs
@@ -31,7 +31,9 @@ pub struct NewIntroBoss<'r> {
     pub textures: GenericArray<ResId<TXTR>, U2>,
 }
 
-use crate::{impl_patterned_info, impl_position, impl_rotation, impl_scale};
+use crate::{
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+};
 impl SclyPropertyData for NewIntroBoss<'_> {
     const OBJECT_TYPE: u8 = 0x0E;
 
@@ -39,6 +41,8 @@ impl SclyPropertyData for NewIntroBoss<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_params);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/oculus.rs
+++ b/structs/src/scly_props/oculus.rs
@@ -1,18 +1,29 @@
 use auto_struct_macros::auto_struct;
-use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
+use reader_writer::{generic_array::GenericArray, typenum::*, CStr, RoArray};
 
-use crate::SclyPropertyData;
+use crate::{scly_props::structs::*, SclyPropertyData};
 
 #[auto_struct(Readable, Writable)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Oculus<'r> {
-    #[auto_struct(expect = 15)]
+    /// 15 everywhere except PAL and NTSC-J, which append one trailing float.
     pub prop_count: u32,
 
     pub name: CStr<'r>,
-    pub dont_care: GenericArray<u8, U646>,
+
+    pub position: GenericArray<f32, U3>,
+    pub rotation: GenericArray<f32, U3>,
+    pub scale: GenericArray<f32, U3>,
+
+    pub patterned_info: PatternedInfo,
+    pub actor_params: ActorParameters,
+
+    #[auto_struct(init = (if prop_count == 15 { 164 } else { 168 }, ()))]
+    pub dont_care: RoArray<'r, u8>,
 }
 
+use crate::impl_actor_scannable_parameters;
 impl SclyPropertyData for Oculus<'_> {
     const OBJECT_TYPE: u8 = 0x6F;
+    impl_actor_scannable_parameters!(actor_params);
 }

--- a/structs/src/scly_props/omega_pirate.rs
+++ b/structs/src/scly_props/omega_pirate.rs
@@ -34,13 +34,17 @@ pub struct OmegaPirate<'r> {
     pub dont_care4: GenericArray<u8, U22>,
 }
 
-use crate::{impl_patterned_info, impl_position, impl_rotation, impl_scale};
+use crate::{
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+};
 impl SclyPropertyData for OmegaPirate<'_> {
     const OBJECT_TYPE: u8 = 0x86;
     impl_position!();
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_params1, actor_params2);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/parasite.rs
+++ b/structs/src/scly_props/parasite.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info_with_auxillary, impl_position, impl_rotation, impl_scale,
-    scly_props::structs::*, SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info_with_auxillary, impl_position,
+    impl_rotation, impl_scale, scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -34,4 +34,5 @@ impl SclyPropertyData for Parasite<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info_with_auxillary!();
+    impl_actor_scannable_parameters!(actor_parameters);
 }

--- a/structs/src/scly_props/phazon_healing_nodule.rs
+++ b/structs/src/scly_props/phazon_healing_nodule.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info_with_auxillary, impl_position, impl_rotation, impl_scale,
-    scly_props::structs::*, SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info_with_auxillary, impl_position,
+    impl_rotation, impl_scale, scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -34,4 +34,5 @@ impl SclyPropertyData for PhazonHealingNodule<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info_with_auxillary!();
+    impl_actor_scannable_parameters!(actor_parameters);
 }

--- a/structs/src/scly_props/pickup.rs
+++ b/structs/src/scly_props/pickup.rs
@@ -39,7 +39,9 @@ pub struct Pickup<'r> {
     pub part: ResId<PART>,
 }
 
-use crate::{impl_active, impl_position, impl_rotation, impl_scale};
+use crate::{
+    impl_active, impl_actor_scannable_parameters, impl_position, impl_rotation, impl_scale,
+};
 impl SclyPropertyData for Pickup<'_> {
     const OBJECT_TYPE: u8 = 0x11;
 
@@ -47,4 +49,5 @@ impl SclyPropertyData for Pickup<'_> {
     impl_position!();
     impl_rotation!();
     impl_scale!();
+    impl_actor_scannable_parameters!(actor_parameters);
 }

--- a/structs/src/scly_props/platform.rs
+++ b/structs/src/scly_props/platform.rs
@@ -44,13 +44,17 @@ pub struct Platform<'r> {
     pub rain_gen_rate: u32,
 }
 
-use crate::{impl_active, impl_position, impl_rotation, impl_scale};
+use crate::{
+    impl_active, impl_actor_scannable_parameters, impl_position, impl_rotation, impl_scale,
+};
 impl SclyPropertyData for Platform<'_> {
     const OBJECT_TYPE: u8 = 0x8;
     impl_active!();
     impl_position!();
     impl_rotation!();
     impl_scale!();
+
+    impl_actor_scannable_parameters!(actor_parameters);
 
     const SUPPORTS_VULNERABILITIES: bool = true;
 

--- a/structs/src/scly_props/player_actor.rs
+++ b/structs/src/scly_props/player_actor.rs
@@ -54,13 +54,17 @@ pub struct PlayerActorParams {
     pub unknown5: Option<u8>,
 }
 
-use crate::{impl_active, impl_position, impl_rotation, impl_scale};
+use crate::{
+    impl_active, impl_actor_scannable_parameters, impl_position, impl_rotation, impl_scale,
+};
 impl SclyPropertyData for PlayerActor<'_> {
     const OBJECT_TYPE: u8 = 0x4c;
     impl_active!();
     impl_position!();
     impl_rotation!();
     impl_scale!();
+
+    impl_actor_scannable_parameters!(actor_params);
 
     const SUPPORTS_VULNERABILITIES: bool = true;
 

--- a/structs/src/scly_props/point_of_interest.rs
+++ b/structs/src/scly_props/point_of_interest.rs
@@ -18,10 +18,11 @@ pub struct PointOfInterest<'r> {
     pub point_size: f32,
 }
 
-use crate::{impl_active, impl_position, impl_rotation};
+use crate::{impl_active, impl_position, impl_rotation, impl_scannable_parameters};
 impl SclyPropertyData for PointOfInterest<'_> {
     const OBJECT_TYPE: u8 = 0x42;
     impl_active!();
     impl_position!();
     impl_rotation!();
+    impl_scannable_parameters!(scan_param);
 }

--- a/structs/src/scly_props/puddle_spore.rs
+++ b/structs/src/scly_props/puddle_spore.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info, impl_position, impl_rotation, impl_scale, scly_props::structs::*,
-    SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+    scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -35,6 +35,8 @@ impl SclyPropertyData for PuddleSpore<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_parameters);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/puddle_toad_gamma.rs
+++ b/structs/src/scly_props/puddle_toad_gamma.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info, impl_position, impl_rotation, impl_scale, scly_props::structs::*,
-    SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+    scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -37,6 +37,8 @@ impl SclyPropertyData for PuddleToadGamma<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_parameters);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/puffer.rs
+++ b/structs/src/scly_props/puffer.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info, impl_position, impl_rotation, impl_scale, scly_props::structs::*,
-    SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+    scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -39,6 +39,8 @@ impl SclyPropertyData for Puffer<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_parameters);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/ridley_v1.rs
+++ b/structs/src/scly_props/ridley_v1.rs
@@ -60,13 +60,17 @@ pub struct RidleyV1<'r> {
     pub damage_info8: DamageInfo,
 }
 
-use crate::{impl_patterned_info, impl_position, impl_rotation, impl_scale};
+use crate::{
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+};
 impl SclyPropertyData for RidleyV1<'_> {
     const OBJECT_TYPE: u8 = 0x7B;
     impl_position!();
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_params);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/ridley_v2.rs
+++ b/structs/src/scly_props/ridley_v2.rs
@@ -61,10 +61,13 @@ pub struct RidleyV2<'r> {
     pub damage_info8: DamageInfo,
 }
 
-use crate::{impl_active, impl_position, impl_rotation, impl_scale};
+use crate::{
+    impl_active, impl_actor_scannable_parameters, impl_position, impl_rotation, impl_scale,
+};
 impl SclyPropertyData for RidleyV2<'_> {
     const OBJECT_TYPE: u8 = 0x7B;
     impl_position!();
     impl_rotation!();
     impl_scale!();
+    impl_actor_scannable_parameters!(actor_params);
 }

--- a/structs/src/scly_props/ripper.rs
+++ b/structs/src/scly_props/ripper.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info_with_auxillary, impl_position, impl_rotation, impl_scale,
-    scly_props::structs::*, SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info_with_auxillary, impl_position,
+    impl_rotation, impl_scale, scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -32,4 +32,5 @@ impl SclyPropertyData for Ripper<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info_with_auxillary!();
+    impl_actor_scannable_parameters!(actor_parameters);
 }

--- a/structs/src/scly_props/seedling.rs
+++ b/structs/src/scly_props/seedling.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info, impl_position, impl_rotation, impl_scale, scly_props::structs::*,
-    SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+    scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -37,6 +37,8 @@ impl SclyPropertyData for Seedling<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_parameters);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/snake_weed_swarm.rs
+++ b/structs/src/scly_props/snake_weed_swarm.rs
@@ -45,12 +45,14 @@ pub struct SnakeWeedSwarm<'r> {
     pub unknown17: u32,
 }
 
-use crate::{impl_active, impl_position, impl_scale};
+use crate::{impl_active, impl_actor_scannable_parameters, impl_position, impl_scale};
 impl SclyPropertyData for SnakeWeedSwarm<'_> {
     const OBJECT_TYPE: u8 = 0x6D;
     impl_active!();
     impl_position!();
     impl_scale!();
+
+    impl_actor_scannable_parameters!(actor_parameters);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/space_pirate.rs
+++ b/structs/src/scly_props/space_pirate.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info, impl_position, impl_rotation, impl_scale, scly_props::structs::*,
-    SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+    scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -41,6 +41,8 @@ impl SclyPropertyData for SpacePirate<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_parameters);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 

--- a/structs/src/scly_props/spank_weed.rs
+++ b/structs/src/scly_props/spank_weed.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info_with_auxillary, impl_position, impl_rotation, impl_scale,
-    scly_props::structs::*, SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info_with_auxillary, impl_position,
+    impl_rotation, impl_scale, scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -33,4 +33,5 @@ impl SclyPropertyData for SpankWeed<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info_with_auxillary!();
+    impl_actor_scannable_parameters!(actor_parameters);
 }

--- a/structs/src/scly_props/thardus.rs
+++ b/structs/src/scly_props/thardus.rs
@@ -28,11 +28,15 @@ pub struct Thardus<'r> {
     pub asset_ids2: GenericArray<u32, U6>,
 }
 
-use crate::{impl_patterned_info_with_auxillary, impl_position, impl_rotation, impl_scale};
+use crate::{
+    impl_actor_scannable_parameters, impl_patterned_info_with_auxillary, impl_position,
+    impl_rotation, impl_scale,
+};
 impl SclyPropertyData for Thardus<'_> {
     const OBJECT_TYPE: u8 = 0x58;
     impl_position!();
     impl_rotation!();
     impl_scale!();
     impl_patterned_info_with_auxillary!();
+    impl_actor_scannable_parameters!(actor_parameters);
 }

--- a/structs/src/scly_props/thardus_rock_projectile.rs
+++ b/structs/src/scly_props/thardus_rock_projectile.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info_with_auxillary, impl_position, impl_rotation, impl_scale,
-    scly_props::structs::*, SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info_with_auxillary, impl_position,
+    impl_rotation, impl_scale, scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -35,4 +35,5 @@ impl SclyPropertyData for ThardusRockProjectile<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info_with_auxillary!();
+    impl_actor_scannable_parameters!(actor_parameters);
 }

--- a/structs/src/scly_props/tryclops.rs
+++ b/structs/src/scly_props/tryclops.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info_with_auxillary, impl_position, impl_rotation, impl_scale,
-    scly_props::structs::*, SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info_with_auxillary, impl_position,
+    impl_rotation, impl_scale, scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -31,4 +31,5 @@ impl SclyPropertyData for Tryclops<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info_with_auxillary!();
+    impl_actor_scannable_parameters!(actor_parameters);
 }

--- a/structs/src/scly_props/wall_crawler_swarm.rs
+++ b/structs/src/scly_props/wall_crawler_swarm.rs
@@ -1,7 +1,7 @@
 use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
-use crate::SclyPropertyData;
+use crate::{scly_props::structs::*, SclyPropertyData};
 
 #[auto_struct(Readable, Writable)]
 #[derive(Debug, Clone, PartialEq)]
@@ -10,9 +10,18 @@ pub struct WallCrawlerSwarm<'r> {
     pub prop_count: u32,
 
     pub name: CStr<'r>,
-    pub dont_care: GenericArray<u8, U454>,
+
+    pub position: GenericArray<f32, U3>,
+    pub rotation: GenericArray<f32, U3>,
+    pub scale: GenericArray<f32, U3>,
+    pub active: u8,
+    pub actor_params: ActorParameters,
+
+    pub dont_care: GenericArray<u8, U292>,
 }
 
+use crate::impl_actor_scannable_parameters;
 impl SclyPropertyData for WallCrawlerSwarm<'_> {
     const OBJECT_TYPE: u8 = 0x5A;
+    impl_actor_scannable_parameters!(actor_params);
 }

--- a/structs/src/scly_props/war_wasp.rs
+++ b/structs/src/scly_props/war_wasp.rs
@@ -2,8 +2,8 @@ use auto_struct_macros::auto_struct;
 use reader_writer::{generic_array::GenericArray, typenum::*, CStr};
 
 use crate::{
-    impl_patterned_info, impl_position, impl_rotation, impl_scale, scly_props::structs::*,
-    SclyPropertyData,
+    impl_actor_scannable_parameters, impl_patterned_info, impl_position, impl_rotation, impl_scale,
+    scly_props::structs::*, SclyPropertyData,
 };
 
 #[auto_struct(Readable, Writable)]
@@ -42,6 +42,8 @@ impl SclyPropertyData for WarWasp<'_> {
     impl_rotation!();
     impl_scale!();
     impl_patterned_info!();
+
+    impl_actor_scannable_parameters!(actor_parameters);
 
     const SUPPORTS_DAMAGE_INFOS: bool = true;
 


### PR DESCRIPTION
# Changes

- add `scannableParameters` to `editObjs`, allowing JSON API users to replace the SCAN data for individual instances of an arbitrary object
  - hard-codes FRME 0xDCEC3E77 and empty scan images
- automatically handle:
  - SCAN/STRG asset creation and deduplication
  - pak/SCLY dependency insertion
  - SAVW insertion (remember scan progress and reserve space in logbook)
- refactor implementation shared with existing `extraScans` feature

# Schema

<img width="1374" height="2179" alt="Screenshot_1" src="https://github.com/user-attachments/assets/aa25a539-6642-4f67-8200-2e7990e79dd5" />

# Why?

I plan on finishing Shale's scan tips PR
