### PR TITLE
Fix Elite Research Pickup always being active

### DIFF
--- a/src/patches.rs
+++ b/src/patches.rs
@@ -18619,7 +18619,7 @@ fn patch_elite_research_persistent_pickup(
 
     // Layer starts Inactive by Default
     let flags = &mut area.layer_flags.flags;
-    *flags &= !(1 << 6);
+    *flags &= !(1 << pickup_active_layer);
 
     let special_fn_id = area.new_object_id_from_layer_id(0);
     let pickup_timer_id = area.new_object_id_from_layer_name("Pickup Active");


### PR DESCRIPTION
# Issue
On the persistent pickup layer, the flags bitwise was checking explicitly for layer 6, which when playing with DLR that would be the doors layer, making the persistent pickup layer being 7, thus remaining active

# Solution
Specify `pickup_active_layer` instead of `6`

# Verification
<img width="1087" height="604" alt="Screenshot 2026-08-11 073322" src="https://github.com/user-attachments/assets/dcf41a3c-07cc-49a5-9d6a-2f984e9aa1ae" />
<img width="1122" height="633" alt="Screenshot 2026-08-11 073325" src="https://github.com/user-attachments/assets/ec4eb61e-f702-4204-aacf-a41ba1cf17cf" />
